### PR TITLE
Adding support for pydantic extras in models

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,14 @@ paths are considered internals and can change in minor and patch releases.
 v5.0.0 (unreleased)
 -------------------
 
+Added
+^^^^^
+- Support for Pydantic models with ``extra`` field configuration (``allow``,
+  ``forbid``, ``ignore``). Models with ``extra="allow"`` now accept additional
+  fields, while ``extra="forbid"`` properly rejects them and ``extra="ignore"``
+  accepts but ignores extra fields during instantiation (`#732
+  <https://github.com/omni-us/jsonargparse/pull/732>`__).
+
 Changed
 ^^^^^^^
 - The print config argument now defaults to ``--print_<config_arg_name>``,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,11 +17,10 @@ v5.0.0 (unreleased)
 
 Added
 ^^^^^
-- Support for Pydantic models with ``extra`` field configuration (``allow``,
-  ``forbid``, ``ignore``). Models with ``extra="allow"`` now accept additional
-  fields, while ``extra="forbid"`` properly rejects them and ``extra="ignore"``
-  accepts but ignores extra fields during instantiation (`#732
-  <https://github.com/omni-us/jsonargparse/pull/732>`__).
+- Pydantic models configured with ``extra`` as ``"allow"`` or ``"ignore"`` now
+  accept keys that are not in their signature, which are forwarded to the model
+  on instantiation (`#732
+  <https://github.com/mauvilsa/jsonargparse/pull/732>`__).
 
 Changed
 ^^^^^^^

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -532,7 +532,9 @@ Types can be nested with any complexity. Notes about the support:
   and pydantic's ``BaseModel`` are supported, even when nested. By default they
   don't accept subclasses, see :ref:`subclasses-disabled` and
   :ref:`enable-disable-subclasses`. A dataclass that also inherits from a normal
-  class does accept subclasses by default.
+  class does accept subclasses by default. A pydantic model configured with
+  ``extra`` as ``"allow"`` or ``"ignore"`` accepts keys not in its signature,
+  which are forwarded to the model on instantiation.
 
 - User-defined ``Generic`` types are supported, see :ref:`generic-types`.
 

--- a/jsonargparse/_completions_jsonschema.py
+++ b/jsonargparse/_completions_jsonschema.py
@@ -19,7 +19,7 @@ from ._common import (
 )
 from ._jsonschema import ActionJsonSchema
 from ._namespace import Namespace
-from ._optionals import get_doc_short_description
+from ._optionals import get_doc_short_description, pydantic_model_accepts_extra
 from ._required import iter_required_keys, restore_suppressed_required
 from ._subcommands import ActionSubCommands
 from ._typehints import (
@@ -101,6 +101,11 @@ def new_object(description: Optional[str] = None, schema_key: bool = True) -> di
         schema["description"] = description
     schema["properties"] = {config_schema_key: dict(config_schema_key_schema)} if schema_key else {}
     return schema
+
+
+def accepts_extra_keys(parser_or_group) -> bool:
+    """Whether a parser or group corresponds to a pydantic model that accepts unknown keys."""
+    return pydantic_model_accepts_extra(getattr(parser_or_group, "group_class", None))
 
 
 def add_required(schema: dict, key: str) -> None:
@@ -294,7 +299,10 @@ class ParserJsonschema:
     def add_properties(self, parser, schema: dict) -> None:
         required_keys = set(iter_required_keys(parser))
         descriptions = {name: group.title for name, group in parser.groups.items() if group.title}
+        extras = {name for name, group in parser.groups.items() if accepts_extra_keys(group)}
         consts = get_dest_consts(parser)
+        if accepts_extra_keys(parser):
+            schema["additionalProperties"] = True
         for action in filter_non_parsing_actions(parser._actions):
             if isinstance(action, (ActionConfigFile, _ActionConfigLoad)):
                 continue
@@ -303,15 +311,20 @@ class ParserJsonschema:
                 continue
             required = action.dest in required_keys
             action_schema = self.action_schema(action, required, consts.get(action.dest))
-            self.set_dest(schema, action.dest, action_schema, required, descriptions)
+            self.set_dest(schema, action.dest, action_schema, required, descriptions, extras)
 
-    def set_dest(self, schema: dict, dest: str, dest_schema: dict, required: bool, descriptions: dict) -> None:
+    def set_dest(
+        self, schema: dict, dest: str, dest_schema: dict, required: bool, descriptions: dict, extras: set
+    ) -> None:
         keys = dest.split(".")
         node = schema
         for num, key in enumerate(keys[:-1]):
             properties = node.setdefault("properties", {})
+            nested_key = ".".join(keys[: num + 1])
             if properties.get(key, {}).get("type") != "object":
-                properties[key] = new_object(descriptions.get(".".join(keys[: num + 1])))
+                properties[key] = new_object(descriptions.get(nested_key))
+                if nested_key in extras:
+                    properties[key]["additionalProperties"] = True
             if required:
                 add_required(node, key)
             node = properties[key]

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -1222,7 +1222,17 @@ class ArgumentParser(ActionsContainer, argparse.ArgumentParser):
                     group_key = next((g for g in self.groups if key.startswith(g + ".")), None)
                     if group_key:
                         subkey = key[len(group_key) + 1 :]
-                        raise NSKeyError(f"Group '{group_key}' does not accept option '{subkey}'")
+                        group = self.groups[group_key]
+                        should_raise_error = True
+                        if getattr(group, "group_class", None):
+                            from ._optionals import get_pydantic_extra_config
+
+                            extra_config = get_pydantic_extra_config(group.group_class)
+                            if extra_config in {"allow", "ignore"}:
+                                should_raise_error = False
+                        if should_raise_error:
+                            raise NSKeyError(f"Group '{group_key}' does not accept option '{subkey}'")
+                        continue
                     if self._subcommands_action:
                         if cfg.get(self._subcommands_action.dest):
                             subcommand = f"'{cfg[self._subcommands_action.dest]}'"

--- a/jsonargparse/_core.py
+++ b/jsonargparse/_core.py
@@ -66,6 +66,8 @@ from ._optionals import (
     import_jsonnet,
     import_pyyaml,
     omegaconf_apply,
+    pydantic_model_accepts_extra,
+    pydantic_support,
     pyyaml_available,
 )
 from ._parameter_resolvers import UnknownDefault
@@ -1214,6 +1216,8 @@ class ArgumentParser(ActionsContainer, argparse.ArgumentParser):
                         if not (val == {} and ActionTypeHint.is_subclass_typehint(action)):
                             raise ex
                 else:
+                    if self._accepts_extra_key(key):
+                        continue
                     if isinstance(parent_action, ActionSubCommands) and "." in key:
                         subcommand, subkey = split_key_root(key)
                         ex = NSKeyError(f"Subcommand '{subcommand}' does not accept option '{subkey}'")
@@ -1222,17 +1226,7 @@ class ArgumentParser(ActionsContainer, argparse.ArgumentParser):
                     group_key = next((g for g in self.groups if key.startswith(g + ".")), None)
                     if group_key:
                         subkey = key[len(group_key) + 1 :]
-                        group = self.groups[group_key]
-                        should_raise_error = True
-                        if getattr(group, "group_class", None):
-                            from ._optionals import get_pydantic_extra_config
-
-                            extra_config = get_pydantic_extra_config(group.group_class)
-                            if extra_config in {"allow", "ignore"}:
-                                should_raise_error = False
-                        if should_raise_error:
-                            raise NSKeyError(f"Group '{group_key}' does not accept option '{subkey}'")
-                        continue
+                        raise NSKeyError(f"Group '{group_key}' does not accept option '{subkey}'")
                     if self._subcommands_action:
                         if cfg.get(self._subcommands_action.dest):
                             subcommand = f"'{cfg[self._subcommands_action.dest]}'"
@@ -1314,6 +1308,22 @@ class ArgumentParser(ActionsContainer, argparse.ArgumentParser):
         with parser_context(parent_parser=self):
             return super().print_usage(*args, **kwargs)
 
+    def _accepts_extra_key(self, key: str) -> bool:
+        """Whether a key that has no action is accepted as an unknown key of a pydantic model."""
+        if not pydantic_support or find_action(self, key):
+            return False
+        if self._subcommands_action:
+            for name, subparser in self._subcommands_action._name_parser_map.items():
+                if key.startswith(name + "."):
+                    return subparser._accepts_extra_key(key[len(name) + 1 :])
+        groups = self.groups or {}
+        group_key = max((g for g in groups if key.startswith(g + ".")), key=len, default=None)
+        subkey = key if group_key is None else key[len(group_key) + 1 :]
+        if "." in subkey:
+            return False
+        container = self if group_key is None else groups[group_key]
+        return pydantic_model_accepts_extra(getattr(container, "group_class", None))
+
     def _apply_actions(
         self,
         cfg: Namespace | dict[str, Any],
@@ -1358,6 +1368,8 @@ class ArgumentParser(ActionsContainer, argparse.ArgumentParser):
 
             if action is None or isinstance(action, ActionSubCommands):
                 value = cfg[key]
+                if action is None and self._accepts_extra_key(key):
+                    continue  # unknown key of a pydantic model, its value is given as is to the model
                 if isinstance(value, dict):
                     value = Namespace(value)
                 if isinstance(value, Namespace):

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -551,3 +551,57 @@ def get_pydantic_path_type(typehint) -> Union[str, None]:
             if metadata_class.__module__ == "pydantic.types" and metadata_class.__name__ == "PathType":
                 return metadata.path_type
     return None
+
+
+def get_pydantic_extra_config(class_type) -> Union[str, None]:
+    """Get the 'extra' configuration from a Pydantic model.
+
+    Args:
+        class_type: The class to check for Pydantic extra configuration.
+
+    Returns:
+        The extra configuration ('allow', 'forbid', 'ignore') or None if not a Pydantic model.
+    """
+    pydantic_model_version = is_pydantic_model(class_type)
+    if not pydantic_model_version:
+        return None
+
+    try:
+
+        # Handle Pydantic v2 models
+        if pydantic_model_version > 1:
+            # Check for model_config attribute (Pydantic v2 style)
+            if hasattr(class_type, "model_config"):
+                config = class_type.model_config
+                if hasattr(config, "get"):
+                    # ConfigDict case
+                    return config.get("extra")
+                elif hasattr(config, "extra"):
+                    # Direct attribute access
+                    return config.extra
+
+            # Check for __config__ attribute (legacy support in v2)
+            if hasattr(class_type, "__config__"):
+                config = class_type.__config__
+                if hasattr(config, "extra"):
+                    return config.extra
+
+        # Handle Pydantic v1 models (including v1 compatibility mode in v2)
+        else:
+            if hasattr(class_type, "__config__"):
+                config = class_type.__config__
+                if hasattr(config, "extra"):
+                    extra_value = config.extra
+                    # Handle Pydantic v1 Extra enum
+                    if hasattr(extra_value, "value"):
+                        return extra_value.value
+                    elif isinstance(extra_value, str):
+                        return extra_value
+                    else:
+                        # Convert enum to string by taking the last part after the dot
+                        return str(extra_value).split(".")[-1]
+
+    except Exception:
+        # If anything goes wrong, return None to fall back to default behavior
+        pass
+    return None

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -553,55 +553,24 @@ def get_pydantic_path_type(typehint) -> Union[str, None]:
     return None
 
 
-def get_pydantic_extra_config(class_type) -> Union[str, None]:
-    """Get the 'extra' configuration from a Pydantic model.
+def pydantic_model_accepts_extra(class_type) -> bool:
+    """Whether class_type is a pydantic model with ``extra`` set to ``"allow"`` or ``"ignore"``."""
+    pydantic_model = is_pydantic_model(class_type)
+    if not pydantic_model:
+        return False
+    if pydantic_model > 1:
+        extra = class_type.model_config.get("extra")
+    else:  # v1 configs inherit extra=ignore, so only what the model defines counts
+        configs = class_type.__config__.__mro__[:-2]  # excludes pydantic's BaseConfig and object
+        extra = next((c.__dict__["extra"] for c in configs if "extra" in c.__dict__), None)
+    return getattr(extra, "value", extra) in {"allow", "ignore"}
 
-    Args:
-        class_type: The class to check for Pydantic extra configuration.
 
-    Returns:
-        The extra configuration ('allow', 'forbid', 'ignore') or None if not a Pydantic model.
-    """
-    pydantic_model_version = is_pydantic_model(class_type)
-    if not pydantic_model_version:
-        return None
-
-    try:
-
-        # Handle Pydantic v2 models
-        if pydantic_model_version > 1:
-            # Check for model_config attribute (Pydantic v2 style)
-            if hasattr(class_type, "model_config"):
-                config = class_type.model_config
-                if hasattr(config, "get"):
-                    # ConfigDict case
-                    return config.get("extra")
-                elif hasattr(config, "extra"):
-                    # Direct attribute access
-                    return config.extra
-
-            # Check for __config__ attribute (legacy support in v2)
-            if hasattr(class_type, "__config__"):
-                config = class_type.__config__
-                if hasattr(config, "extra"):
-                    return config.extra
-
-        # Handle Pydantic v1 models (including v1 compatibility mode in v2)
-        else:
-            if hasattr(class_type, "__config__"):
-                config = class_type.__config__
-                if hasattr(config, "extra"):
-                    extra_value = config.extra
-                    # Handle Pydantic v1 Extra enum
-                    if hasattr(extra_value, "value"):
-                        return extra_value.value
-                    elif isinstance(extra_value, str):
-                        return extra_value
-                    else:
-                        # Convert enum to string by taking the last part after the dot
-                        return str(extra_value).split(".")[-1]
-
-    except Exception:
-        # If anything goes wrong, return None to fall back to default behavior
-        pass
-    return None
+def get_pydantic_extra_fields(value) -> dict:
+    """Returns the extra fields kept by a model instance, which only happens for ``extra="allow"``."""
+    pydantic_model = is_pydantic_model(type(value))
+    if not pydantic_model or not pydantic_model_accepts_extra(type(value)):
+        return {}
+    if pydantic_model > 1:
+        return dict(value.__pydantic_extra__ or {})
+    return {k: v for k, v in vars(value).items() if k not in value.__fields__}

--- a/jsonargparse/_signatures.py
+++ b/jsonargparse/_signatures.py
@@ -18,7 +18,13 @@ from ._common import (
 )
 from ._instantiation import dynamic_class_instantiator
 from ._namespace import Namespace, get_value_and_parent
-from ._optionals import attrs_support, get_doc_short_description, is_attrs_class, is_pydantic_model
+from ._optionals import (
+    attrs_support,
+    get_doc_short_description,
+    get_pydantic_extra_fields,
+    is_attrs_class,
+    is_pydantic_model,
+)
 from ._parameter_resolvers import ParamData, get_parameter_origins, get_signature_parameters
 from ._required import set_required
 from ._typehints import (
@@ -132,17 +138,21 @@ class SignatureArguments(LoggerProperty):
             skip = skip or set()
             prefix = nested_key + "." if nested_key else ""
             defaults = default
+            extras: dict = {}
             if isinstance(default, _LazyInitBaseClass):
                 defaults = default.lazy_get_init_args().as_dict()
             elif is_convertible_to_dict(default.__class__):
                 defaults = convert_to_dict(default)
+                extras = get_pydantic_extra_fields(default)
                 args = {k[len(prefix) :] for k in added_args}
                 skip_not_added = [k for k in defaults if k not in args]
                 if skip_not_added:
-                    skip.update(skip_not_added)  # skip init=False
+                    skip.update(skip_not_added)  # skip init=False and pydantic extra fields
             if defaults:
                 defaults = {prefix + k: v for k, v in defaults.items() if k not in skip}  # type: ignore[union-attr]
                 self.set_defaults(**defaults)  # type: ignore[attr-defined]
+            if extras:
+                set_group_extra_defaults(self, nested_key, extras)
 
         return added_args
 
@@ -644,6 +654,13 @@ class SignatureArguments(LoggerProperty):
         return group
 
 
+def set_group_extra_defaults(parser, nested_key, extras: dict) -> None:
+    """Sets the defaults of pydantic extra fields in the config load action of a group."""
+    action = next((a for a in parser._actions if isinstance(a, _ActionConfigLoad) and a.dest == nested_key), None)
+    if action:
+        action.default = Namespace(**extras)
+
+
 def group_instantiate_class(group, cfg):
     try:
         value, parent, key = get_value_and_parent(cfg, group.dest)
@@ -677,7 +694,7 @@ def convert_to_dict(value) -> dict:
 
     value_type = type(value)
     init_args = {}
-    for name, attr in vars(value).items():
+    for name, attr in {**vars(value), **get_pydantic_extra_fields(value)}.items():
         attr_type = type(attr)
         if is_convertible_to_dict(attr_type):
             attr = convert_to_dict(attr)

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -317,6 +317,8 @@ def cached_get_class_parser(*, val_class, sub_add_kwargs, skip_args, parent_pars
         parser.link_arguments(**link_kwargs)
 
     parser._inner_parser = True
+    # the parser as a whole corresponds to val_class, like a group does for a nested key
+    parser.group_class = val_class
 
     _cached_class_parsers[cache_key] = parser
     return parser

--- a/jsonargparse_tests/test_pydantic.py
+++ b/jsonargparse_tests/test_pydantic.py
@@ -23,6 +23,7 @@ from jsonargparse_tests.conftest import (
     capture_logs,
     get_parse_args_stdout,
     get_parser_help,
+    json_or_yaml_dump,
     json_or_yaml_load,
     skip_if_docstring_parser_unavailable,
 )
@@ -32,13 +33,12 @@ if pydantic_support:
 
 annotated = typing_extensions_import("Annotated")
 
-skip_if_pydantic_v1_on_v2 = pytest.mark.skipif(
-    pydantic_support and pydantic is getattr(__import__("pydantic"), "v1", None),
-    reason="Not supported for pydantic.v1",
-)
+pydantic_v1_on_v2 = bool(pydantic_support) and pydantic is getattr(__import__("pydantic"), "v1", None)
+
+skip_if_pydantic_v1_on_v2 = pytest.mark.skipif(pydantic_v1_on_v2, reason="Not supported for pydantic.v1")
 
 skip_if_pydantic_v1 = pytest.mark.skipif(
-    pydantic_support < 2 or pydantic is getattr(__import__("pydantic"), "v1", None),
+    pydantic_support < 2 or pydantic_v1_on_v2,
     reason="Not supported for pydantic v1",
 )
 
@@ -885,3 +885,162 @@ def test_pydantic_alias_conflicting_with_added_argument_skipped(parser, logger):
         cfg = parser.parse_args(["--m.el=3"])
     assert cfg.m.el == 3
     assert "Parsed command line arguments" in logs.getvalue()
+
+
+if pydantic_support:
+
+    class PydanticExtraAllow(pydantic.BaseModel, extra="allow"):  # type: ignore[call-arg]
+        p1: str
+        p2: int = 3
+
+    class PydanticExtraIgnore(pydantic.BaseModel, extra="ignore"):  # type: ignore[call-arg]
+        p1: str
+        p2: int = 3
+
+    class PydanticExtraForbid(pydantic.BaseModel, extra="forbid"):  # type: ignore[call-arg]
+        p1: str
+
+    class RequiresExtraAllow:
+        def __init__(self, model: PydanticExtraAllow):
+            self.model = model
+
+    class PydanticNestedExtraAllow(pydantic.BaseModel, extra="allow"):  # type: ignore[call-arg]
+        nested: PydanticModel = PydanticModel(p1="a")
+
+    class PydanticNestingExtraAllow(pydantic.BaseModel):
+        nested: PydanticExtraAllow = PydanticExtraAllow(p1="a")
+
+
+def test_pydantic_extra_allow_group_argument(parser):
+    parser.add_argument("--model", type=PydanticExtraAllow, default=PydanticExtraAllow(p1="a"))
+    cfg = parser.parse_object({"model": {"p1": "x", "p3": "y"}})
+    assert cfg.model == Namespace(p1="x", p2=3, p3="y")
+    init = parser.instantiate(cfg)
+    assert isinstance(init.model, PydanticExtraAllow)
+    assert init.model.p3 == "y"
+    assert json_or_yaml_load(parser.dump(cfg))["model"] == {"p1": "x", "p2": 3, "p3": "y"}
+
+
+def test_pydantic_extra_allow_add_class_arguments(parser, subtests):
+    parser.add_class_arguments(PydanticExtraAllow, "model")
+
+    with subtests.test("value with extras"):
+        cfg = parser.parse_args(['--model={"p1": "x", "p3": {"a": 1}}'])
+        assert cfg.model == Namespace(p1="x", p2=3, p3={"a": 1})
+        init = parser.instantiate(cfg)
+        assert init.model.p3 == {"a": 1}
+
+    with subtests.test("extras not added as options"):
+        with pytest.raises(ArgumentError, match="unrecognized arguments: --model.p3=y"):
+            parser.parse_args(["--model.p1=x", "--model.p3=y"])
+
+
+def test_pydantic_extra_allow_optional_model(parser):
+    parser.add_argument("--model", type=Optional[PydanticExtraAllow])
+    cfg = parser.parse_args(['--model={"p1": "x"}', "--model.p3=y"])
+    assert cfg.model == Namespace(p1="x", p2=3, p3="y")
+    init = parser.instantiate(cfg)
+    assert isinstance(init.model, PydanticExtraAllow)
+    assert init.model.p3 == "y"
+
+
+def test_pydantic_extra_allow_nested_in_class(parser):
+    parser.add_class_arguments(RequiresExtraAllow, "cls")
+    cfg = parser.parse_args(['--cls.model={"p1": "x", "p3": [1, 2]}'])
+    assert cfg.cls.model == Namespace(p1="x", p2=3, p3=[1, 2])
+    init = parser.instantiate(cfg)
+    assert init.cls.model.p3 == [1, 2]
+
+
+def test_pydantic_extra_allow_in_subclass_init_args(parser):
+    parser.add_argument("--cls", type=RequiresExtraAllow)
+    value = {"class_path": f"{__name__}.RequiresExtraAllow", "init_args": {"model": {"p1": "x", "p3": "y"}}}
+    cfg = parser.parse_args([f"--cls={json.dumps(value)}"])
+    assert cfg.cls.init_args.model == Namespace(p1="x", p2=3, p3="y")
+    init = parser.instantiate(cfg)
+    assert init.cls.model.p3 == "y"
+
+
+def test_pydantic_extra_ignore_group_argument(parser):
+    parser.add_argument("--model", type=PydanticExtraIgnore, default=PydanticExtraIgnore(p1="a"))
+    cfg = parser.parse_object({"model": {"p1": "x", "p3": "y"}})
+    assert cfg.model == Namespace(p1="x", p2=3, p3="y")
+    init = parser.instantiate(cfg)
+    assert isinstance(init.model, PydanticExtraIgnore)
+    assert not hasattr(init.model, "p3")
+    assert json_or_yaml_load(parser.dump(cfg))["model"] == {"p1": "x", "p2": 3, "p3": "y"}
+
+
+def test_pydantic_extra_not_accepted(subtests):
+    for model in [PydanticExtraForbid, PydanticModel]:
+        with subtests.test(model.__name__):
+            parser = ArgumentParser(exit_on_error=False)
+            parser.add_class_arguments(model, "model")
+            with pytest.raises(ArgumentError, match="Group 'model' does not accept option 'p3'"):
+                parser.parse_object({"model": {"p1": "x", "p3": "y"}})
+
+
+def test_pydantic_extra_allow_default_with_extras(subtests):
+    for name, model_type in [("group", PydanticExtraAllow), ("optional", Optional[PydanticExtraAllow])]:
+        with subtests.test(name):
+            parser = ArgumentParser(exit_on_error=False)
+            parser.add_argument("--model", type=model_type, default=PydanticExtraAllow(p1="a", p3="y"))
+            cfg = parser.parse_args([])
+            assert cfg.model.p3 == "y"
+            assert json_or_yaml_load(parser.dump(cfg))["model"]["p3"] == "y"
+            init = parser.instantiate(cfg)
+            assert init.model.p3 == "y"
+
+
+def test_pydantic_extra_allow_jsonschema(parser):
+    parser.add_argument("--model", type=PydanticExtraAllow)
+    parser.add_argument("--ignore", type=PydanticExtraIgnore)
+    parser.add_argument("--other", type=PydanticExtraForbid)
+    parser.add_argument("--optional", type=Optional[PydanticExtraAllow])
+    schema = json.loads(parser.get_completion_script("jsonschema"))
+    assert schema["properties"]["model"]["additionalProperties"] is True
+    assert schema["properties"]["ignore"]["additionalProperties"] is True
+    assert schema["properties"]["other"]["additionalProperties"] is False
+    assert schema["$defs"]["PydanticExtraAllow"]["additionalProperties"] is True
+    assert schema["additionalProperties"] is False
+
+
+def test_pydantic_extra_allow_only_direct_fields(parser, subtests):
+    parser.add_argument("--outer", type=PydanticNestedExtraAllow)
+    parser.add_argument("--inner", type=PydanticNestingExtraAllow)
+
+    with subtests.test("nested model not accepting extras"):
+        with pytest.raises(ArgumentError, match="Group 'outer' does not accept option 'nested.p3'"):
+            parser.parse_object({"outer": {"nested": {"p3": "y"}}})
+
+    with subtests.test("model accepting extras only nested"):
+        with pytest.raises(ArgumentError, match="Group 'inner' does not accept option 'p3'"):
+            parser.parse_object({"inner": {"p3": "y"}})
+        cfg = parser.parse_object({"inner": {"nested": {"p3": "y"}}})
+        assert cfg.inner.nested == Namespace(p1="a", p2=3, p3="y")
+
+    with subtests.test("nested model still parsed as a group"):
+        cfg = parser.parse_object({"outer": {"nested": {"p1": "x"}, "p3": {"a": 1}}})
+        assert cfg.outer == Namespace(nested=Namespace(p1="x", p2=3), p3={"a": 1})
+        init = parser.instantiate(cfg)
+        assert isinstance(init.outer.nested, PydanticModel)
+        assert init.outer.p3 == {"a": 1}
+
+
+def test_pydantic_extra_allow_config_file(parser, tmp_cwd):
+    parser.add_argument("--cfg", action="config")
+    parser.add_argument("--model", type=PydanticExtraAllow)
+    pathlib.Path("config.yaml").write_text(json_or_yaml_dump({"model": {"p1": "x", "p3": "y"}}))
+    cfg = parser.parse_args(["--cfg=config.yaml"])
+    assert cfg.model == Namespace(p1="x", p2=3, p3="y")
+    assert parser.instantiate(cfg).model.p3 == "y"
+
+
+def test_pydantic_extra_allow_in_subcommand(parser, subparser):
+    subparser.add_argument("--model", type=PydanticExtraAllow)
+    parser.add_subcommands().add_subcommand("fit", subparser)
+    cfg = parser.parse_args(["fit", '--model={"p1": "x", "p3": "y"}'])
+    assert cfg.fit.model == Namespace(p1="x", p2=3, p3="y")
+    assert parser.instantiate(cfg).fit.model.p3 == "y"
+    with pytest.raises(ArgumentError, match="Subcommand 'fit' does not accept option 'p3'"):
+        parser.parse_object({"fit": {"p3": "y"}})


### PR DESCRIPTION
This PR adds support for Pydantic models with `extra` field configuration (`allow`, `forbid`, `ignore`). 

**Key changes:**
- Models with `extra="allow"` now accept and include additional fields during parsing and instantiation
- Models with `extra="forbid"` properly reject extra fields with clear error messages  
- Models with `extra="ignore"` accept extra fields during parsing but ignore them during instantiation
- Support for both Pydantic v1 and v2 syntax and configuration styles

**Behavior:**
- `extra="allow"`: Extra fields are accepted and included in the final model
- `extra="forbid"`: Extra fields cause a `NSKeyError` during parsing
- `extra="ignore"`: Extra fields are accepted during parsing but ignored during model instantiation
- Default behavior remains unchanged for models without explicit extra configuration

This resolves the limitation where jsonargparse would always reject extra fields regardless of the Pydantic model's `extra` configuration.

- [x] Did you read the [contributing guideline](https://github.com/omni-us/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)