### PR TITLE
fix: discard previous class defaults on subclass class_path change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,10 @@ Fixed
 - ``TypedDict`` keys inherited from a base defined in a different module not
   resolving the types only imported in the ``TYPE_CHECKING`` block of that
   module (`#936 <https://github.com/mauvilsa/jsonargparse/pull/936>`__).
+- Init args of a default subclass instance not being discarded on class path
+  change when they are only the previous class defaults, thereby shadowing the
+  defaults of the newly selected class (`#460
+  <https://github.com/mauvilsa/jsonargparse/issues/460>`__).
 
 Changed
 ^^^^^^^

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -1765,6 +1765,16 @@ def dump_kwargs_context(kwargs):
     yield
 
 
+def get_class_defaults(class_path, parser_or_action) -> Namespace:
+    if not class_path:
+        return Namespace()
+    sub_add_kwargs = getattr(parser_or_action, "sub_add_kwargs", {})
+    try:
+        return ActionTypeHint.get_class_parser(class_path, sub_add_kwargs).get_defaults()
+    except Exception:
+        return Namespace()
+
+
 def discard_init_args_on_class_path_change(parser_or_action, prev_val, value):
     if prev_val and "init_args" in prev_val and prev_val["class_path"] != value["class_path"]:
         parser = parser_or_action
@@ -1772,8 +1782,15 @@ def discard_init_args_on_class_path_change(parser_or_action, prev_val, value):
             sub_add_kwargs = getattr(parser_or_action, "sub_add_kwargs", {})
             parser = ActionTypeHint.get_class_parser(value["class_path"], sub_add_kwargs)
         del_args = {}
+        del_defaults = {}
         prev_val = subclass_spec_as_namespace(prev_val)
+        prev_defaults = get_class_defaults(prev_val["class_path"], parser_or_action)
+        new_defaults = get_class_defaults(value["class_path"], parser_or_action)
         for key, val in list(prev_val.init_args.items(branches=True, nested=False)):
+            if key in prev_defaults and key in new_defaults and prev_defaults[key] == val and new_defaults[key] != val:
+                # value is only the previous class default, so the new class default must prevail
+                del_defaults[key] = prev_val.init_args.pop(key)
+                continue
             action = find_action(parser, key)
             if action:
                 with parser_context(lenient_check=False, load_value_mode=parser.parser_mode):
@@ -1787,6 +1804,11 @@ def discard_init_args_on_class_path_change(parser_or_action, prev_val, value):
             parser_or_action.logger.debug(
                 f"Due to class_path change from {prev_val['class_path']!r} to {value['class_path']!r}, "
                 f"discarding init_args: {del_args}."
+            )
+        if del_defaults:
+            parser_or_action.logger.debug(
+                f"Due to class_path change from {prev_val['class_path']!r} to {value['class_path']!r}, "
+                f"discarding previous class defaults: {del_defaults}."
             )
 
 

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -1059,6 +1059,27 @@ def test_subclass_discard_init_args_mixed_type(parser, logger):
     assert "discarding init_args: {'param': 1}" in logs.getvalue()
 
 
+class DefaultInstanceBase:
+    pass
+
+
+class DefaultInstanceSub1(DefaultInstanceBase):
+    def __init__(self, foo: str = "foo", bar: str = "bar"):
+        pass  # pragma: no cover
+
+
+class DefaultInstanceSub2(DefaultInstanceBase):
+    def __init__(self, foo: str = "foo", bar: str = "baaaaar"):
+        pass  # pragma: no cover
+
+
+def test_subclass_discard_default_instance_defaults_on_class_path_change(parser):
+    parser.add_argument("--data", type=DefaultInstanceBase, default=lazy_instance(DefaultInstanceSub1))
+    cfg = parser.parse_args([f"--data={__name__}.DefaultInstanceSub2", "--data.foo=test"])
+    assert cfg.data.class_path == f"{__name__}.DefaultInstanceSub2"
+    assert cfg.data.init_args == Namespace(foo="test", bar="baaaaar")
+
+
 class OverrideBase:
     def __init__(self, b: int = 1):
         pass  # pragma: no cover


### PR DESCRIPTION
## What does this PR do?

Fixes #460. When a subclass argument has a default instance, its init_args were carried over to a newly selected class as long as they were valid for it. For init args that are merely the previous class's defaults, that shadowed the new class's own defaults, so `--data Other --data.foo test` still printed `Default`'s `bar` value. Init args whose value equals the previous class default and whose new class default differs are now discarded; explicitly given values are unaffected since they no longer equal the previous default.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/mauvilsa/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] If you used a **coding agent**, did you fully understand and validate all generated code and ensure it follows the contributing guidelines?
- [ ] Did you update **the documentation**? (readme and public docstrings) — n/a, no public API change
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] If this is a **bug fix**, did you verify that the **tests fail without the code fix**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
