### PR TITLE
Deprecate instantiation of subclass specs in Any and missing --print_%s deprecation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -172,7 +172,7 @@ Fixed
   empty line, observed since bash 5.3 (`#954
   <https://github.com/mauvilsa/jsonargparse/pull/954>`__).
 - Missing deprecation warning for the ``--print_config`` to ``--print_%s``
-  change (`#??? <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
+  change (`#955 <https://github.com/mauvilsa/jsonargparse/pull/955>`__).
 
 Changed
 ^^^^^^^
@@ -212,6 +212,17 @@ Changed
   option 'init_args....'``. Dataclass-like types now accept the same values
   whether or not they are added as a group, see :ref:`subclasses-disabled`
   (`#952 <https://github.com/mauvilsa/jsonargparse/pull/952>`__).
+
+Deprecated
+^^^^^^^^^^
+- Instantiating a subclass spec given as value for a type that accepts any
+  value, i.e. ``Any`` or ``Unvalidated<...>``, is deprecated. From v5.0.0 the
+  subclass spec will be kept as is, so that the code that receives it decides
+  whether to instantiate it. The new ``instantiate_subclass_spec_in_any``
+  setting in ``set_parsing_settings`` allows getting the future behavior now,
+  ``False``, or keeping the current one, ``True``. Enabling it is discouraged
+  since it means that a config is able to instantiate any class, which can be a
+  security risk (`#955 <https://github.com/mauvilsa/jsonargparse/pull/955>`__).
 
 
 v4.50.0 (2026-07-22)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -171,6 +171,8 @@ Fixed
   guidance message when there are zero completions, leaving the cursor on an
   empty line, observed since bash 5.3 (`#954
   <https://github.com/mauvilsa/jsonargparse/pull/954>`__).
+- Missing deprecation warning for the ``--print_config`` to ``--print_%s``
+  change (`#??? <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
 
 Changed
 ^^^^^^^
@@ -193,8 +195,6 @@ Changed
   Parameter and return types must still match exactly, except when the protocol
   has no annotation or ``Any`` (`#941
   <https://github.com/mauvilsa/jsonargparse/pull/941>`__).
-- The default print config argument name will remain as ``--print_config`` in
-  v5.0.0, no longer changing as described in the deprecated section of v4.35.0.
 - A signature parameter typed as ``jsonargparse.Namespace`` now raises a
   ``ValueError`` when adding the arguments, instead of the parameter being
   silently skipped. ``Namespace`` is only intended for parsing results (`#948

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -2259,6 +2259,14 @@ be accepted. In this case the config would be like:
     ``class_path`` and ``init_args`` if the corresponding parameter has type
     ``Any``, or when ``fail_untyped=False`` which defaults to type ``Any``.
 
+    The instantiation of these values is deprecated. From v5.0.0 the subclass
+    spec will be kept as is, so that the code that receives it decides whether
+    to instantiate it. Set ``instantiate_subclass_spec_in_any=False`` in
+    :func:`.set_parsing_settings` to get this behavior now and silence the
+    deprecation warning. Setting it to ``True`` keeps the instantiation, but it
+    is discouraged since it means that a config is able to instantiate any
+    class, which can be a security risk.
+
     If a value looks like a subclass spec (has a ``class_path``) but cannot be
     parsed as one, e.g. because the class fails to import, by default it is left
     unchanged and a debug message is logged. Set

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -1,5 +1,6 @@
 """Collection of useful actions to define arguments."""
 
+import os
 import re
 import sys
 from argparse import SUPPRESS, _HelpAction, _VersionAction
@@ -107,6 +108,21 @@ class ActionConfigFile(Action):
         if isinstance(action, ActionConfigFile) and getattr(container, "_print_config", None) is not None:
             if "%s" in container._print_config:
                 container._print_config = container._print_config % action.dest
+            elif (
+                container._print_config == "--print_config"
+                and action.dest != "config"
+                and os.getenv("JSONARGPARSE_DEPRECATION_WARNINGS", "").lower() == "all"
+            ):
+                from ._deprecated import deprecation_warning
+
+                deprecation_warning(
+                    "print_config_default_name",
+                    "From v5.0.0 the print config argument will by default reuse the name of the config "
+                    'argument as "--print_%s". The current default is always "--print_config", but in v5.0.0 '
+                    f'with a config argument named "{action.dest}" it will become "--print_{action.dest}". '
+                    'To keep the current name set print_config="--print_config" explicitly.',
+                    stacklevel=2,
+                )
             assert container._print_config.startswith("--")
             container.add_argument(container._print_config, action=_ActionPrintConfig)
 

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -119,6 +119,7 @@ def parser_context(**kwargs):
 parsing_settings: dict = {
     "validate_defaults": False,
     "validate_subclass_spec_in_any": False,
+    "instantiate_subclass_spec_in_any": None,  # v5.0.0: change default to False
     "parse_optionals_as_positionals": False,
     "add_print_completion_argument": False,
     "stubs_resolver_allow_py_files": False,
@@ -139,6 +140,7 @@ def set_parsing_settings(
     *,
     validate_defaults: bool | None = None,
     validate_subclass_spec_in_any: bool | None = None,
+    instantiate_subclass_spec_in_any: bool | None = None,
     config_read_mode_urls_enabled: bool | None = None,
     config_read_mode_fsspec_enabled: bool | None = None,
     docstring_parse_style: "docstring_parser.DocstringStyle | None" = None,
@@ -166,6 +168,14 @@ def set_parsing_settings(
             since the value is kept as a dict. By default, this is ``False``,
             meaning that an invalid subclass spec is ignored (a debug log is
             emitted) and the original value is kept.
+        instantiate_subclass_spec_in_any: Whether ``instantiate`` builds the
+            class when a value for a type that accepts any value, i.e. ``Any``
+            or ``Unvalidated<...>``, is a valid subclass spec. If ``False``, the
+            value is kept as a subclass spec, which the code that receives it
+            can instantiate itself if desired. Currently the default is ``True``
+            and a deprecation warning is emitted, since from v5.0.0 the default
+            will be ``False``. Enabling it is discouraged because it means that
+            any class can be instantiated, so only do it for trusted configs.
         config_read_mode_urls_enabled: Whether to read config files from URLs
             using requests package. Default is ``False``.
         config_read_mode_fsspec_enabled: Whether to read config files from
@@ -216,6 +226,13 @@ def set_parsing_settings(
         parsing_settings["validate_subclass_spec_in_any"] = validate_subclass_spec_in_any
     elif validate_subclass_spec_in_any is not None:
         raise ValueError(f"validate_subclass_spec_in_any must be a boolean, but got {validate_subclass_spec_in_any}.")
+    # instantiate_subclass_spec_in_any
+    if isinstance(instantiate_subclass_spec_in_any, bool):
+        parsing_settings["instantiate_subclass_spec_in_any"] = instantiate_subclass_spec_in_any
+    elif instantiate_subclass_spec_in_any is not None:
+        raise ValueError(
+            f"instantiate_subclass_spec_in_any must be a boolean, but got {instantiate_subclass_spec_in_any}."
+        )
     # config_read_mode
     if config_read_mode_urls_enabled is not None:
         _set_config_read_mode(urls_enabled=config_read_mode_urls_enabled)

--- a/jsonargparse/_deprecated.py
+++ b/jsonargparse/_deprecated.py
@@ -1068,6 +1068,28 @@ def deprecated_implicit_subcommand(component, subcommand_keys: list[str], subcom
     )
 
 
+instantiate_subclass_spec_in_any_message = """
+    Instantiating a subclass spec given as value for a type that accepts any value, i.e. ``Any`` or
+    ``Unvalidated<...>``, was deprecated in v4.51.0. From v5.0.0 these values will no longer be
+    instantiated, the subclass spec being kept as is, so that the code that receives it decides
+    whether to instantiate it. Set ``instantiate_subclass_spec_in_any=False`` in
+    ``set_parsing_settings`` to get the future behavior now and silence this warning. Setting it to
+    ``True`` keeps the current behavior, but it is discouraged since it means that a config is able
+    to instantiate any class, which can be a security risk.
+"""
+
+
+def unset_instantiate_subclass_spec_in_any() -> bool:
+    """Value used for the ``instantiate_subclass_spec_in_any`` setting when it is unset.
+
+    Remove in v5.0.0, changing the default of the setting from ``None`` to
+    ``False``, and thus making ``_typehints.instantiate_subclass_spec_in_any``
+    only get the setting.
+    """
+    deprecation_warning("instantiate_subclass_spec_in_any", instantiate_subclass_spec_in_any_message)
+    return True
+
+
 def renamed_parameter_warning(renames: dict[str, str], stacklevel: int = 1):
 
     def decorator(func):

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -2194,8 +2194,20 @@ def subclasses_disabled_remove_class_path(value):
     return value
 
 
+def instantiate_subclass_spec_in_any() -> bool:
+    """Whether a subclass spec given as value for a type that accepts any value is instantiated."""
+    setting = get_parsing_setting("instantiate_subclass_spec_in_any")
+    if setting is None:  # remove in v5.0.0, when the setting default becomes False
+        from ._deprecated import unset_instantiate_subclass_spec_in_any
+
+        setting = unset_instantiate_subclass_spec_in_any()
+    return setting
+
+
 def adapt_classes_any(val, typehint, serialize, instantiate_classes, sub_add_kwargs, logger=None):
     if is_subclass_spec(val):
+        if instantiate_classes and not instantiate_subclass_spec_in_any():
+            return val
         orig_val = val
         val = subclass_spec_as_namespace(val)
         init_args = val.get("init_args")

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -1200,6 +1200,46 @@ def test_deprecated_print_config_skip_null(parser):
     )
 
 
+def test_deprecated_print_config_default_name(monkeypatch):
+    monkeypatch.delenv("JSONARGPARSE_DEPRECATION_WARNINGS", raising=False)
+
+    # No warning when the config dest is "config".
+    parser = ArgumentParser(exit_on_error=False)
+    with catch_warnings(record=True) as w:
+        parser.add_argument("--config", action="config")
+    assert w == []
+
+    # No warning without JSONARGPARSE_DEPRECATION_WARNINGS=all, even with another dest.
+    parser = ArgumentParser(exit_on_error=False)
+    with catch_warnings(record=True) as w:
+        parser.add_argument("--cfg", action="config")
+    assert w == []
+
+    monkeypatch.setenv("JSONARGPARSE_DEPRECATION_WARNINGS", "all")
+
+    # No warning with all when the config dest is "config".
+    parser = ArgumentParser(exit_on_error=False)
+    with catch_warnings(record=True) as w:
+        parser.add_argument("--config", action="config")
+    assert w == []
+
+    # No warning when print_config already uses %s.
+    parser = ArgumentParser(exit_on_error=False, print_config="--print_%s")
+    with catch_warnings(record=True) as w:
+        parser.add_argument("--cfg", action="config")
+    assert w == []
+
+    # Warning with all when the config dest differs from "config".
+    parser = ArgumentParser(exit_on_error=False)
+    with catch_warnings(record=True) as w:
+        parser.add_argument("--cfg", action="config")
+    assert_deprecation_warn(
+        w,
+        message='become "--print_cfg"',
+        code='parser.add_argument("--cfg", action="config")',
+    )
+
+
 def test_subcommands_parse_string_first_implicit_subcommand(subcommands_parser):  # noqa: F811
     with catch_warnings(record=True) as w:
         cfg = subcommands_parser.parse_string('{"a": {"ap1": "ap1_cfg"}, "b": {"nums": {"val1": 2}}}')

--- a/jsonargparse_tests/test_deprecated.py
+++ b/jsonargparse_tests/test_deprecated.py
@@ -12,7 +12,7 @@ from importlib import import_module
 from inspect import getmodule as inspect_getmodule
 from io import StringIO
 from types import ModuleType
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import patch
 from warnings import catch_warnings
 
@@ -1428,3 +1428,23 @@ def test_fail_untyped_false_required_parameter_deprecation(parser, monkeypatch):
     assert "In v5 the type will be set to Any but the parameter will remain required" in str(warnings[0].message)
 
     assert parser.get_defaults() == Namespace(a1=None, a2=None, b1=None, b2=None)
+
+
+def test_instantiate_subclass_spec_in_any_deprecation(parser):
+    shown_deprecation_warnings.clear()
+    parser.add_argument("--any", type=Any)
+    spec = {"class_path": "calendar.TextCalendar", "init_args": {"firstweekday": 2}}
+    cfg = parser.parse_args([f"--any={json.dumps(spec)}"])
+
+    with catch_warnings(record=True) as w:
+        init = parser.instantiate(cfg)
+    assert isinstance(init.any, Calendar)
+    assert init.any.firstweekday == 2
+    assert len(w) == 2
+    assert "will no longer be instantiated" in str(w[-1].message)
+    assert "instantiate_subclass_spec_in_any" in str(w[-1].message)
+
+    with catch_warnings(record=True) as w:
+        init = parser.instantiate(cfg)
+    assert isinstance(init.any, Calendar)
+    assert w == []

--- a/jsonargparse_tests/test_parsing_settings.py
+++ b/jsonargparse_tests/test_parsing_settings.py
@@ -3,6 +3,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
 from unittest.mock import patch
+from warnings import catch_warnings
 
 import pytest
 
@@ -472,7 +473,7 @@ def test_unset_parse_and_print_config(parser):
 
 class AnySubclass:
     def __init__(self, p: int = 0):
-        self.p = p  # pragma: no cover
+        self.p = p
 
 
 def test_set_validate_subclass_spec_in_any_failure():
@@ -610,3 +611,75 @@ def test_validate_subclass_spec_in_any_enabled_union_dict_fails(parser):
         parser.parse_args([f'--union={{"class_path": "{__name__}.AnySubclass", "init_args": {{"nope": 1}}}}'])
     ctx.match("Does not validate against any of the Union subtypes")
     ctx.match("Invalid subclass spec given as value for type Dict")
+
+
+# instantiate_subclass_spec_in_any
+
+
+any_subclass_spec = {"class_path": f"{__name__}.AnySubclass", "init_args": {"p": 3}}
+any_subclass_namespace = Namespace(class_path=f"{__name__}.AnySubclass", init_args=Namespace(p=3))
+
+
+def test_set_instantiate_subclass_spec_in_any_failure():
+    with pytest.raises(ValueError, match="instantiate_subclass_spec_in_any must be a boolean"):
+        set_parsing_settings(instantiate_subclass_spec_in_any="invalid")
+
+
+def test_instantiate_subclass_spec_in_any_default_is_none():
+    assert get_parsing_setting("instantiate_subclass_spec_in_any") is None
+
+
+def test_instantiate_subclass_spec_in_any_enabled(parser):
+    set_parsing_settings(instantiate_subclass_spec_in_any=True)
+    parser.add_argument("--any", type=Any)
+
+    cfg = parser.parse_args([f"--any={json.dumps(any_subclass_spec)}"])
+    assert cfg.any == any_subclass_namespace
+
+    with catch_warnings(record=True) as warns:
+        init = parser.instantiate(cfg)
+    assert warns == []
+    assert isinstance(init.any, AnySubclass)
+    assert init.any.p == 3
+
+
+def test_instantiate_subclass_spec_in_any_disabled(parser):
+    set_parsing_settings(instantiate_subclass_spec_in_any=False)
+    parser.add_argument("--any", type=Any)
+
+    cfg = parser.parse_args([f"--any={json.dumps(any_subclass_spec)}"])
+    assert cfg.any == any_subclass_namespace
+
+    with catch_warnings(record=True) as warns:
+        init = parser.instantiate(cfg)
+    assert warns == []
+    assert init.any == any_subclass_namespace
+
+    assert json_or_yaml_load(parser.dump(cfg)) == {"any": any_subclass_spec}
+
+
+def test_instantiate_subclass_spec_in_any_disabled_nested_in_list_and_dict(parser):
+    set_parsing_settings(instantiate_subclass_spec_in_any=False)
+    parser.add_argument("--any", type=Any)
+
+    cfg = parser.parse_args([f"--any={json.dumps({'k': [any_subclass_spec]})}"])
+    init = parser.instantiate(cfg)
+    assert init.any == {"k": [any_subclass_namespace]}
+
+
+def test_instantiate_subclass_spec_in_any_disabled_unvalidated_type(parser):
+    set_parsing_settings(instantiate_subclass_spec_in_any=False)
+    parser.add_argument("--unvalidated", type=UnvalidatedType("some.SomeType"))
+
+    cfg = parser.parse_args([f"--unvalidated={json.dumps(any_subclass_spec)}"])
+    init = parser.instantiate(cfg)
+    assert init.unvalidated == any_subclass_namespace
+
+
+def test_instantiate_subclass_spec_in_any_disabled_invalid_spec_kept(parser):
+    set_parsing_settings(instantiate_subclass_spec_in_any=False)
+    parser.add_argument("--any", type=Any)
+
+    cfg = parser.parse_args(['--any={"class_path": "nonexistent.Foo"}'])
+    init = parser.instantiate(cfg)
+    assert init.any == {"class_path": "nonexistent.Foo"}


### PR DESCRIPTION
## What does this PR do?

Two deprecations for v5.0.0:

### Instantiation of subclass specs in `Any`

When a value for a type that accepts anything (`Any` or `Unvalidated<...>`) is a valid
subclass spec, `instantiate_classes` currently builds the class. This is deprecated: from
v5.0.0 the subclass spec will be kept as is, leaving it to the code that receives it to
decide whether to instantiate. Instantiating is a security risk, since it means a config
can instantiate any class.

A new `instantiate_subclass_spec_in_any` setting in `set_parsing_settings` allows opting
into the future behavior now (`False`, silencing the warning) or keeping the current one
(`True`, discouraged). The setting defaults to `None`, which behaves as `True` and emits
the deprecation warning; in v5.0.0 the default becomes `False` and the deprecated path is
removed.

### `--print_config` to `--print_%s`

The name change announced in v4.35.0 never emitted a warning. One is now raised (under
`JSONARGPARSE_DEPRECATION_WARNINGS=all`) when the config argument is not named `config`,
so the print config argument name will change in v5.0.0.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/mauvilsa/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] If you used a **coding agent**, did you fully understand and validate all generated code and ensure it follows the contributing guidelines?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [n/a] If this is a **bug fix**, did you verify that the **tests fail without the code fix**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
