### PR TITLE
Handle object as Any, and support subscripted generic protocols and TypedDicts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,12 +20,13 @@ Added
 - ``validate_subclass_spec_in_any`` setting in ``set_parsing_settings`` so that
   when a value looks like a subclass spec but is not a valid one, the parsing
   fails instead of silently ignoring it. Applies to types that accept any value,
-  i.e. ``Any``, ``Unvalidated<...>`` and dicts that don't validate their values,
-  e.g. ``dict[str, Any]``. For dicts the spec is only validated, since the value
-  is kept as a dict. When disabled (the default), a debug log now informs about
-  the ignored invalid subclass spec (`#938
+  i.e. ``Any``, ``object``, ``Unvalidated<...>`` and dicts that don't validate
+  their values, e.g. ``dict[str, Any]``. For dicts the spec is only validated,
+  since the value is kept as a dict. When disabled (the default), a debug log
+  now informs about the ignored invalid subclass spec (`#938
   <https://github.com/mauvilsa/jsonargparse/pull/938>`__, `#953
-  <https://github.com/mauvilsa/jsonargparse/pull/953>`__).
+  <https://github.com/mauvilsa/jsonargparse/pull/953>`__, `#???
+  <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
 - Items of a list of classes and values of a dict of classes can now be given as
   paths to sub-config files, instead of this only being supported for the value
   of an entire argument (`#940
@@ -53,8 +54,11 @@ Added
   <https://github.com/mauvilsa/jsonargparse/pull/952>`__).
 - A ``TypeVar`` used as the type itself, i.e. not only as the subtype of a
   ``type[...]``, is now replaced by what it stands for: its PEP 696 ``default``,
-  its constraints or its bound. Previously the value was accepted without any
-  validation (`#953 <https://github.com/mauvilsa/jsonargparse/pull/953>`__).
+  its constraints or its bound, resolving it when given as a forward reference,
+  e.g. ``TypeVar("OptionsT", default="Options[int]")``. Previously the value was
+  accepted without any validation, see :ref:`generic-types` (`#953
+  <https://github.com/mauvilsa/jsonargparse/pull/953>`__, `#???
+  <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
 - Arguments typed as a ``TypedDict`` now have a ``--*.help`` option that shows
   the keys that are accepted, their types and their descriptions. It receives no
   value, unless the ``TypedDict`` is in a union with other types that have a
@@ -74,6 +78,10 @@ Added
   the class itself. The parsed namespace and dumps use the name that the class
   accepts, see :ref:`parameter-aliases` (`#956
   <https://github.com/mauvilsa/jsonargparse/pull/956>`__).
+- Support a subscripted ``TypedDict``, e.g. ``Options[int]`` for a ``class
+  Options(TypedDict, Generic[T])``, previously an unsupported type. The type
+  arguments are substituted into the keys annotated with a ``TypeVar`` (`#???
+  <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
 
 Fixed
 ^^^^^
@@ -167,8 +175,10 @@ Fixed
   <https://github.com/mauvilsa/jsonargparse/pull/953>`__).
 - A generic ``Protocol`` never being implementable, since the ``TypeVar`` of the
   protocol and the type in the implementation could never be equal. Now a
-  ``TypeVar`` in either of them matches any type, as static type checkers do
-  (`#953 <https://github.com/mauvilsa/jsonargparse/pull/953>`__).
+  ``TypeVar`` in either of them matches any type, as static type checkers do,
+  both for the unsubscripted and the subscripted spelling, e.g. ``Proto`` and
+  ``Proto[int]`` (`#953 <https://github.com/mauvilsa/jsonargparse/pull/953>`__,
+  `#??? <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
 - Classes having no parameters at all when a decorator wraps ``__new__``, e.g.
   decorators that mark a class as deprecated or experimental. The parameters
   were resolved from the wrapper instead of from ``__init__`` (`#953
@@ -264,17 +274,23 @@ Changed
   implementation was rejected and giving its fields directly failed on
   ``instantiate``. See :ref:`subclasses-disabled` (`#956
   <https://github.com/mauvilsa/jsonargparse/pull/956>`__).
+- ``object`` as a type is now handled exactly like ``Any``, since in standard
+  typing every value is an instance of it. Previously it was treated as a class
+  type, so values were neither parsed nor validated as for ``Any``, and the help
+  showed an inapplicable ``--*.help`` option and ``known subclasses`` listing
+  (`#??? <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
 
 Deprecated
 ^^^^^^^^^^
 - Instantiating a subclass spec given as value for a type that accepts any
-  value, i.e. ``Any`` or ``Unvalidated<...>``, is deprecated. From v5.0.0 the
-  subclass spec will be kept as is, so that the code that receives it decides
-  whether to instantiate it. The new ``instantiate_subclass_spec_in_any``
-  setting in ``set_parsing_settings`` allows getting the future behavior now,
-  ``False``, or keeping the current one, ``True``. Enabling it is discouraged
-  since it means that a config is able to instantiate any class, which can be a
-  security risk (`#955 <https://github.com/mauvilsa/jsonargparse/pull/955>`__).
+  value, i.e. ``Any``, ``object`` or ``Unvalidated<...>``, is deprecated. From
+  v5.0.0 the subclass spec will be kept as is, so that the code that receives it
+  decides whether to instantiate it. The new
+  ``instantiate_subclass_spec_in_any`` setting in ``set_parsing_settings``
+  allows getting the future behavior now, ``False``, or keeping the current one,
+  ``True``. Enabling it is discouraged since it means that a config is able to
+  instantiate any class, which can be a security risk (`#955
+  <https://github.com/mauvilsa/jsonargparse/pull/955>`__).
 
 
 v4.50.0 (2026-07-22)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,8 +25,8 @@ Added
   since the value is kept as a dict. When disabled (the default), a debug log
   now informs about the ignored invalid subclass spec (`#938
   <https://github.com/mauvilsa/jsonargparse/pull/938>`__, `#953
-  <https://github.com/mauvilsa/jsonargparse/pull/953>`__, `#???
-  <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
+  <https://github.com/mauvilsa/jsonargparse/pull/953>`__, `#958
+  <https://github.com/mauvilsa/jsonargparse/pull/958>`__).
 - Items of a list of classes and values of a dict of classes can now be given as
   paths to sub-config files, instead of this only being supported for the value
   of an entire argument (`#940
@@ -54,11 +54,11 @@ Added
   <https://github.com/mauvilsa/jsonargparse/pull/952>`__).
 - A ``TypeVar`` used as the type itself, i.e. not only as the subtype of a
   ``type[...]``, is now replaced by what it stands for: its PEP 696 ``default``,
-  its constraints or its bound, resolving it when given as a forward reference,
-  e.g. ``TypeVar("OptionsT", default="Options[int]")``. Previously the value was
-  accepted without any validation, see :ref:`generic-types` (`#953
-  <https://github.com/mauvilsa/jsonargparse/pull/953>`__, `#???
-  <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
+  its constraints or its bound, also when given as a forward reference.
+  Previously the value was accepted without any validation, see
+  :ref:`generic-types` (`#953
+  <https://github.com/mauvilsa/jsonargparse/pull/953>`__, `#958
+  <https://github.com/mauvilsa/jsonargparse/pull/958>`__).
 - Arguments typed as a ``TypedDict`` now have a ``--*.help`` option that shows
   the keys that are accepted, their types and their descriptions. It receives no
   value, unless the ``TypedDict`` is in a union with other types that have a
@@ -78,10 +78,11 @@ Added
   the class itself. The parsed namespace and dumps use the name that the class
   accepts, see :ref:`parameter-aliases` (`#956
   <https://github.com/mauvilsa/jsonargparse/pull/956>`__).
-- Support a subscripted ``TypedDict``, e.g. ``Options[int]`` for a ``class
-  Options(TypedDict, Generic[T])``, previously an unsupported type. The type
-  arguments are substituted into the keys annotated with a ``TypeVar`` (`#???
-  <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
+- Support a subscripted generic ``TypedDict``, e.g. ``SomeDict[int]``, and a
+  ``TypedDict`` that inherits from one, e.g. ``class SubDict(SomeDict[int])``,
+  previously unsupported types. The type arguments are substituted into the keys
+  annotated with a ``TypeVar``, see :ref:`type-hints` (`#958
+  <https://github.com/mauvilsa/jsonargparse/pull/958>`__).
 
 Fixed
 ^^^^^
@@ -173,12 +174,12 @@ Fixed
   silently making the mask the actual secret. Now parsing the mask as a
   ``SecretStr``, both jsonargparse's and pydantic's, fails (`#953
   <https://github.com/mauvilsa/jsonargparse/pull/953>`__).
-- A generic ``Protocol`` never being implementable, since the ``TypeVar`` of the
-  protocol and the type in the implementation could never be equal. Now a
-  ``TypeVar`` in either of them matches any type, as static type checkers do,
-  both for the unsubscripted and the subscripted spelling, e.g. ``Proto`` and
-  ``Proto[int]`` (`#953 <https://github.com/mauvilsa/jsonargparse/pull/953>`__,
-  `#??? <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
+- A generic ``Protocol`` never being implementable, both unsubscripted and
+  subscripted, e.g. ``Proto`` and ``Proto[int]``. Now the type arguments are
+  substituted and a ``TypeVar`` that remains matches any type, as static type
+  checkers do, see :ref:`type-hints` (`#953
+  <https://github.com/mauvilsa/jsonargparse/pull/953>`__, `#958
+  <https://github.com/mauvilsa/jsonargparse/pull/958>`__).
 - Classes having no parameters at all when a decorator wraps ``__new__``, e.g.
   decorators that mark a class as deprecated or experimental. The parameters
   were resolved from the wrapper instead of from ``__init__`` (`#953
@@ -229,17 +230,29 @@ Fixed
   instantiate with ``TypeError: got an unexpected keyword argument`` or not
   being configurable at all (`#956
   <https://github.com/mauvilsa/jsonargparse/pull/956>`__).
+- Internal ``RuntimeError`` when giving a value for a ``TypedDict`` key
+  annotated with a ``TypeVar``, e.g. a generic ``TypedDict``, see
+  :ref:`generic-types` (`#958
+  <https://github.com/mauvilsa/jsonargparse/pull/958>`__).
+- ``type[Any]`` rejecting every value, instead of accepting any class as
+  ``type`` without an argument does (`#958
+  <https://github.com/mauvilsa/jsonargparse/pull/958>`__).
+- The docstring of a subscripted generic class not being used, so the group
+  description and the parameter descriptions were missing in the help (`#958
+  <https://github.com/mauvilsa/jsonargparse/pull/958>`__).
 
 Changed
 ^^^^^^^
 - Signature parameters with a type that jsonargparse can't validate are now
-  accepted instead of skipped. Only the parts of the type that can't be
-  validated accept any value, e.g. a ``list[SomeType]`` still requires a list.
-  These parts are shown in the help as ``Unvalidated<...>`` and a debug log
-  states the reason. See the new documentation section :ref:`unvalidated-types`
-  (`#936 <https://github.com/mauvilsa/jsonargparse/pull/936>`__, `#944
+  accepted, instead of the parameter being skipped and the key failing to parse.
+  Only the parts of the type that can't be validated accept any value, e.g. a
+  ``list[SomeType]`` still requires a list. These parts are shown in the help as
+  ``Unvalidated<...>`` and a debug log states the reason. See the new
+  documentation section :ref:`unvalidated-types` (`#936
+  <https://github.com/mauvilsa/jsonargparse/pull/936>`__, `#944
   <https://github.com/mauvilsa/jsonargparse/pull/944>`__, `#948
-  <https://github.com/mauvilsa/jsonargparse/pull/948>`__).
+  <https://github.com/mauvilsa/jsonargparse/pull/948>`__, `#958
+  <https://github.com/mauvilsa/jsonargparse/pull/958>`__).
 - ``Required`` and ``NotRequired`` given as the type of an argument are no
   longer shown in the help. Now they must agree with whether the argument is
   required, otherwise adding the argument fails (`#937
@@ -275,10 +288,8 @@ Changed
   ``instantiate``. See :ref:`subclasses-disabled` (`#956
   <https://github.com/mauvilsa/jsonargparse/pull/956>`__).
 - ``object`` as a type is now handled exactly like ``Any``, since in standard
-  typing every value is an instance of it. Previously it was treated as a class
-  type, so values were neither parsed nor validated as for ``Any``, and the help
-  showed an inapplicable ``--*.help`` option and ``known subclasses`` listing
-  (`#??? <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
+  typing every value is an instance of it (`#958
+  <https://github.com/mauvilsa/jsonargparse/pull/958>`__).
 
 Deprecated
 ^^^^^^^^^^

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -550,9 +550,10 @@ Some notes about this support are:
   compatible, as specified in PEP `589 <https://peps.python.org/pep-0589/>`__,
   i.e. it has all the keys of the expected ``TypedDict``, with the same types
   and requiredness. A generic ``TypedDict`` is supported both unsubscripted and
-  subscripted, e.g. ``Options`` and ``Options[int]``. Subscripting doesn't
-  change which keys are accepted, only the types of the keys annotated with a
-  ``TypeVar``.
+  subscripted, e.g. ``SomeDict`` and ``SomeDict[int]``, as is a ``TypedDict``
+  that inherits from a subscripted one. Subscripting doesn't change which keys
+  are accepted, only the types of the keys annotated with a ``TypeVar``. A key
+  whose type can't be validated accepts any value, see :ref:`unvalidated-types`.
 
 - ``tuple``, ``set``, ``frozenset``, ``AbstractSet`` and ``MutableSet`` are
   supported even though they can't be represented in JSON distinguishable from
@@ -581,7 +582,9 @@ Some notes about this support are:
   return types must match exactly, subtypes are not accepted, except when the
   protocol has no annotation or ``Any``, which accept any type. A generic
   protocol is supported both unsubscripted and subscripted, e.g. ``Proto`` and
-  ``Proto[int]``. In both cases a ``TypeVar``, in the protocol or in the
+  ``Proto[int]``. Subscripting substitutes the type arguments in the protocol's
+  methods, so ``Proto[int]`` and ``Proto[str]`` accept different
+  implementations. A ``TypeVar`` that remains, in the protocol or in the
   implementation, matches any type, as static type checkers do.
 
 - ``dataclasses``, final classes, attrs' ``define``, pydantic's ``dataclass``
@@ -713,7 +716,8 @@ When arguments are added from a signature, i.e. :meth:`add_function_arguments
 <.ArgumentParser.add_method_arguments>`, :meth:`add_class_arguments
 <.ArgumentParser.add_class_arguments>` or a parameter of a :ref:`subclass type
 <sub-classes>`, there can be parameters with a type that jsonargparse can't
-validate. Instead of skipping these parameters, which would make it impossible
+validate. The same holds for the keys of a ``TypedDict``, however the argument
+is added. Instead of skipping these parameters, which would make it impossible
 to give them in the command line or a config file, the parameter is added with
 only the parts of the type that can't be validated replaced by a type that
 accepts any value. In the help these parts are shown as ``Unvalidated<...>``,
@@ -729,7 +733,8 @@ A type or a part of it can't be validated when:
 
 - It failed to resolve, e.g. a missing import or a typo in a postponed
   annotation.
-- It is not a type that jsonargparse supports.
+- It is not a type that jsonargparse supports, e.g. a ``TypeVar`` that stands
+  for nothing, see :ref:`generic-types`.
 
 To know which of the two it is for a given parameter, enable debut level
 logging, see :ref:`logging`. The debug log states the reason for each of the

--- a/DOCUMENTATION.rst
+++ b/DOCUMENTATION.rst
@@ -523,12 +523,12 @@ Some notes about this support are:
   :ref:`boolean-arguments`), ``int``, ``float``, ``Decimal``, ``complex``,
   ``bytes``/``bytearray`` (Base64 encoding), ``range``, ``list`` (more details
   in :ref:`list-append`), ``Deque``, ``Iterable``, ``Sequence``,
-  ``MutableSequence``, ``Collection``, ``Container``, ``Reversible``, ``Any``,
-  ``Union``/``Optional`` (more details in :ref:`union-types`), ``Type``,
-  ``Enum``, ``PathLike``, ``UUID``, ``timedelta``, restricted types as explained
-  in sections :ref:`restricted-numbers` and :ref:`restricted-strings` and path
-  and URL types as explained in sections :ref:`parsing-paths` and
-  :ref:`parsing-urls`.
+  ``MutableSequence``, ``Collection``, ``Container``, ``Reversible``,
+  ``Any``/``object``, ``Union``/``Optional`` (more details in
+  :ref:`union-types`), ``Type``, ``Enum``, ``PathLike``, ``UUID``,
+  ``timedelta``, restricted types as explained in sections
+  :ref:`restricted-numbers` and :ref:`restricted-strings` and path and URL types
+  as explained in sections :ref:`parsing-paths` and :ref:`parsing-urls`.
 
 - ``dict``, ``Mapping``, ``MutableMapping``, ``MappingProxyType``,
   ``OrderedDict``, and ``TypedDict`` are supported but only with ``str`` or
@@ -549,7 +549,10 @@ Some notes about this support are:
   ``issubclass``, the given class is accepted when it is structurally
   compatible, as specified in PEP `589 <https://peps.python.org/pep-0589/>`__,
   i.e. it has all the keys of the expected ``TypedDict``, with the same types
-  and requiredness.
+  and requiredness. A generic ``TypedDict`` is supported both unsubscripted and
+  subscripted, e.g. ``Options`` and ``Options[int]``. Subscripting doesn't
+  change which keys are accepted, only the types of the keys annotated with a
+  ``TypeVar``.
 
 - ``tuple``, ``set``, ``frozenset``, ``AbstractSet`` and ``MutableSet`` are
   supported even though they can't be represented in JSON distinguishable from
@@ -576,7 +579,10 @@ Some notes about this support are:
   i.e. the methods must be callable in all the ways that the protocol's methods
   can be called, similar to what static type checkers verify. Parameter and
   return types must match exactly, subtypes are not accepted, except when the
-  protocol has no annotation or ``Any``, which accept any type.
+  protocol has no annotation or ``Any``, which accept any type. A generic
+  protocol is supported both unsubscripted and subscripted, e.g. ``Proto`` and
+  ``Proto[int]``. In both cases a ``TypeVar``, in the protocol or in the
+  implementation, matches any type, as static type checkers do.
 
 - ``dataclasses``, final classes, attrs' ``define``, pydantic's ``dataclass``
   and pydantic's ``BaseModel`` are supported even when nested. By default they
@@ -645,12 +651,11 @@ the argument is added, so that the subtypes that validate get a chance of being
 used. From first to last attempted, the groups are:
 
 1. All types not mentioned below, in the order in which they are written.
-2. ``object``, which accepts the import path of any class, making any class
-   subtype after it unreachable.
-3. ``None``, which only accepts ``null``. It is placed second to last so that
+2. ``None``, which only accepts ``null``. It is placed second to last so that
    ``Optional[<type>]`` reads in the help as it does in the source code.
-4. ``Any`` and the types that can't be validated, see :ref:`unvalidated-types`.
-   These accept any value, so a subtype after them would never be attempted.
+3. ``Any``, ``object`` and the types that can't be validated, see
+   :ref:`unvalidated-types`. These accept any value, so a subtype after them
+   would never be attempted.
 
 The sorting is stable, meaning that subtypes in the same group keep the relative
 order in which they are given. Unions nested inside other types are sorted as
@@ -749,7 +754,7 @@ the config formats represent round-trip. For instance, a ``set`` is serialized
 as a list and parses back as a list, and an ``Enum`` member is serialized as its
 name and parses back as a string. A warning is raised for each dumped value that
 loses its type this way. All of the above equally applies to arguments typed as
-``Any``.
+``Any``/``object``.
 
 
 .. _restricted-numbers:
@@ -1209,9 +1214,12 @@ Parsing complex-valued points would be:
 
 A ``TypeVar`` can't be used to validate, so when it is used as a type, e.g.
 ``options: Optional[OptionsT] = None``, it is replaced by what it stands for:
-its PEP 696 ``default``, its constraints or its bound, in that order. When it
-has none of these, the value is accepted without validation and the help shows
-it as ``Unvalidated<...>``.
+its PEP 696 ``default``, its constraints or its bound, in that order. Any of
+these given as a forward reference, e.g. ``TypeVar("OptionsT",
+default="Options[int]")``, is resolved with the names of the module in which the
+``TypeVar`` is defined. When the ``TypeVar`` has none of these, or the forward
+reference fails to resolve, the value is accepted without validation and the
+help shows it as ``Unvalidated<...>``.
 
 
 .. _callable-type:
@@ -2314,7 +2322,8 @@ be accepted. In this case the config would be like:
 
     Classes will be parsed and instantiated when given as value a dict with
     ``class_path`` and ``init_args`` if the corresponding parameter has type
-    ``Any``, or when ``fail_untyped=False`` which defaults to type ``Any``.
+    ``Any`` or ``object``, or when ``fail_untyped=False`` which defaults to type
+    ``Any``.
 
     The instantiation of these values is deprecated. From v5.0.0 the subclass
     spec will be kept as is, so that the code that receives it decides whether
@@ -2328,8 +2337,9 @@ be accepted. In this case the config would be like:
     parsed as one, e.g. because the class fails to import, by default it is left
     unchanged and a debug message is logged. Set
     ``validate_subclass_spec_in_any=True`` in :func:`.set_parsing_settings` to
-    make the parsing fail instead. Apart from ``Any`` and ``Unvalidated<...>``,
-    this also applies to dicts that don't validate their values, e.g.
+    make the parsing fail instead. Apart from ``Any``, ``object`` and
+    ``Unvalidated<...>``, this also applies to dicts that don't validate their
+    values, e.g.
     ``dict[str, Any]``. For dicts the spec is only validated, since the value is
     kept as a dict, which matters for unions such as ``Union[SomeClass,
     dict[str, Any]]``, where a spec rejected by the class member would otherwise

--- a/jsonargparse/_actions.py
+++ b/jsonargparse/_actions.py
@@ -346,8 +346,9 @@ class _ActionHelpClassPath(NonParsingAction):
 
         self._typehint = kwargs.pop("_typehint")
         self._help_types = get_help_types(self._typehint)
-        assert self._help_types and all(isinstance(b, type) for b in self._help_types)
         typed_dicts = [t for t in self._help_types if is_typed_dict(t)]
+        # a subscripted generic typed dict is a generic alias instead of a class, see get_typed_dict_type
+        assert self._help_types and all(isinstance(b, type) for b in self._help_types if b not in typed_dicts)
         # a single type means that the help refers to it, so no value is expected
         single_type = len(self._help_types) == 1 and (is_subclasses_disabled(self._help_types[0]) or bool(typed_dicts))
         self._basename = iter_to_set_str(t.__name__ for t in self._help_types)

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -400,7 +400,8 @@ def get_unaliased_type(cls):
 
 def is_pure_dataclass(cls) -> bool:
     classes = [c for c in inspect.getmro(cls) if c not in {object, Generic}]
-    return all(dataclasses.is_dataclass(c) for c in classes)
+    # bool(classes) since e.g. object itself has no class in its mro that could be a dataclass
+    return bool(classes) and all(dataclasses.is_dataclass(c) for c in classes)
 
 
 subclasses_enabled_types: set[type] = set()
@@ -416,7 +417,7 @@ subclasses_disabled_selectors: dict[str, Callable[[type], bool | int]] = {
 def is_subclasses_disabled(cls) -> bool:
     if is_generic_class(cls):
         return is_subclasses_disabled(cls.__origin__)
-    if not inspect.isclass(cls) or cls is object:
+    if not inspect.isclass(cls):
         return False
     # abstract classes are not intended to be instantiated from their own fields, so only subclasses make sense
     subclass_disabled = not is_abstract_class(cls) and any(

--- a/jsonargparse/_common.py
+++ b/jsonargparse/_common.py
@@ -162,21 +162,22 @@ def set_parsing_settings(
             argument type. The default is ``False``, meaning no default
             validation, like in argparse.
         validate_subclass_spec_in_any: If ``True``, when a value for a type that
-            accepts any value, i.e. ``Any``, ``Unvalidated<...>`` or a dict that
-            doesn't validate its values, looks like a subclass spec (i.e. a dict
-            with a ``class_path`` key), it is required to be a valid one,
-            otherwise the parsing fails. For dicts the spec is only validated,
-            since the value is kept as a dict. By default, this is ``False``,
-            meaning that an invalid subclass spec is ignored (a debug log is
-            emitted) and the original value is kept.
+            accepts any value, i.e. ``Any``, ``object``, ``Unvalidated<...>`` or
+            a dict that doesn't validate its values, looks like a subclass spec
+            (i.e. a dict with a ``class_path`` key), it is required to be a
+            valid one, otherwise the parsing fails. For dicts the spec is only
+            validated, since the value is kept as a dict. By default, this is
+            ``False``, meaning that an invalid subclass spec is ignored (a debug
+            log is emitted) and the original value is kept.
         instantiate_subclass_spec_in_any: Whether ``instantiate`` builds the
-            class when a value for a type that accepts any value, i.e. ``Any``
-            or ``Unvalidated<...>``, is a valid subclass spec. If ``False``, the
-            value is kept as a subclass spec, which the code that receives it
-            can instantiate itself if desired. Currently the default is ``True``
-            and a deprecation warning is emitted, since from v5.0.0 the default
-            will be ``False``. Enabling it is discouraged because it means that
-            any class can be instantiated, so only do it for trusted configs.
+            class when a value for a type that accepts any value, i.e. ``Any``,
+            ``object`` or ``Unvalidated<...>``, is a valid subclass spec. If
+            ``False``, the value is kept as a subclass spec, which the code that
+            receives it can instantiate itself if desired. Currently the default
+            is ``True`` and a deprecation warning is emitted, since from v5.0.0
+            the default will be ``False``. Enabling it is discouraged because it
+            means that any class can be instantiated, so only do it for trusted
+            configs.
         config_read_mode_urls_enabled: Whether to read config files from URLs
             using requests package. Default is ``False``.
         config_read_mode_fsspec_enabled: Whether to read config files from
@@ -415,7 +416,7 @@ subclasses_disabled_selectors: dict[str, Callable[[type], bool | int]] = {
 def is_subclasses_disabled(cls) -> bool:
     if is_generic_class(cls):
         return is_subclasses_disabled(cls.__origin__)
-    if not inspect.isclass(cls):
+    if not inspect.isclass(cls) or cls is object:
         return False
     # abstract classes are not intended to be instantiated from their own fields, so only subclasses make sense
     subclass_disabled = not is_abstract_class(cls) and any(

--- a/jsonargparse/_completions.py
+++ b/jsonargparse/_completions.py
@@ -347,7 +347,7 @@ def get_typehint_choices(typehint, prefix, parser, skip, added_subclasses=None) 
             has_explicit_choices = False
             has_open_values = False
             for subtype in typehint.__args__:
-                if subtype in added_subclasses or subtype is object:
+                if subtype in added_subclasses:
                     continue
                 subchoices, subexplicit, subopen = get_choices_state(subtype)
                 choices.extend(subchoices)
@@ -442,7 +442,8 @@ def get_help_class_choices(typehint) -> list[str]:
     choices = []
     if get_typehint_origin(typehint) == Union:
         for subtype in typehint.__args__:
-            if inspect.isclass(subtype):
+            # a subscripted generic typed dict is a generic alias instead of a class
+            if inspect.isclass(subtype) or is_typed_dict(subtype):
                 choices.extend(get_help_class_choices(subtype))
     elif is_typed_dict(typehint):
         choices = [typehint.__name__]  # typed dicts don't accept a class path, only their name

--- a/jsonargparse/_deprecated.py
+++ b/jsonargparse/_deprecated.py
@@ -1069,10 +1069,10 @@ def deprecated_implicit_subcommand(component, subcommand_keys: list[str], subcom
 
 
 instantiate_subclass_spec_in_any_message = """
-    Instantiating a subclass spec given as value for a type that accepts any value, i.e. ``Any`` or
-    ``Unvalidated<...>``, was deprecated in v4.51.0. From v5.0.0 these values will no longer be
-    instantiated, the subclass spec being kept as is, so that the code that receives it decides
-    whether to instantiate it. Set ``instantiate_subclass_spec_in_any=False`` in
+    Instantiating a subclass spec given as value for a type that accepts any value, i.e. ``Any``,
+    ``object`` or ``Unvalidated<...>``, was deprecated in v4.51.0. From v5.0.0 these values will no
+    longer be instantiated, the subclass spec being kept as is, so that the code that receives it
+    decides whether to instantiate it. Set ``instantiate_subclass_spec_in_any=False`` in
     ``set_parsing_settings`` to get the future behavior now and silence this warning. Setting it to
     ``True`` keeps the current behavior, but it is discouraged since it means that a config is able
     to instantiate any class, which can be a security risk.

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -246,6 +246,11 @@ def get_mro_doc_sources(cls) -> list:
 
 
 def parse_docs(component, parent, logger):
+    from ._common import get_generic_origin
+
+    # a subscripted generic, e.g. Strategy[int], is documented by the class that it stands for
+    component = get_generic_origin(component)
+    parent = get_generic_origin(parent)
     docs = {}
     if docstring_parser_support:
         if inspect.isclass(parent) and component.__name__ == "__init__":
@@ -265,6 +270,9 @@ def parse_docs(component, parent, logger):
 
 
 def get_doc_short_description(function_or_class, method_name=None, logger=None):
+    from ._common import get_generic_origin
+
+    function_or_class = get_generic_origin(function_or_class)  # e.g. Strategy[int] documented by Strategy
     if docstring_parser_support:
         if inspect.isclass(function_or_class) and not method_name:
             # nearest short description in the mro, since a derived class often inherits the constructor

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -963,6 +963,11 @@ class UnvalidatedType:
         return hash((UnvalidatedType, self.name))
 
 
+def accepts_any_value(typehint) -> bool:
+    """Whether a type hint accepts any value, i.e. it does not validate."""
+    return typehint is object or typehint == Any or isinstance(typehint, UnvalidatedType)
+
+
 def keep_subtype_as_is(subtype, typehint_origin) -> bool:
     """Whether a subtype is never replaced, mirroring the exceptions that is_supported_typehint makes."""
     return (
@@ -1047,24 +1052,49 @@ def get_typed_dict_type(typehint):
 
     A subscripted generic TypedDict, is a generic alias through which the keys
     can't be looked up. Its type parameters don't change the keys, only the
-    types of the ones annotated with a TypeVar, see get_typed_dict_type_var_map.
+    types of the ones annotated with a TypeVar, see get_typed_dict_type_var_maps.
     """
-    origin = get_typehint_origin(typehint)
+    # __origin__ used directly, since get_typehint_origin is more costly and only
+    # differs for types that are never a TypedDict, e.g. it maps one to dict
+    origin = getattr(typehint, "__origin__", None)
     return origin if type(origin) in typed_dict_meta_types else typehint
 
 
-def get_typed_dict_type_var_map(typehint) -> dict:
-    """Returns the map from the TypeVars of a generic TypedDict to the types it is subscripted with."""
-    typed_dict = get_typed_dict_type(typehint)
-    if typed_dict is typehint:
+def get_type_var_map(typehint, generic) -> dict:
+    """Returns the map from the TypeVars of a generic to the types that it is subscripted with."""
+    if generic is typehint:
         return {}
-    parameters = getattr(typed_dict, "__parameters__", None) or ()
+    parameters = getattr(generic, "__parameters__", None) or ()
     args = getattr(typehint, "__args__", None) or ()
     return dict(zip(parameters, args))
 
 
+def get_typed_dict_type_var_maps(typehint) -> dict:
+    """Returns the map from each key of a generic TypedDict to the TypeVar substitutions that apply to it.
+
+    A key inherited from a base is substituted with what the base is
+    subscripted with, e.g. ``class Sub(Base[int])``, composed with the
+    substitutions of the subclass, e.g. ``class Sub(Base[T])`` used as
+    ``Sub[int]``. Thus, the same TypeVar can stand for a different type
+    depending on the key in which it is used, so a map per key is needed.
+    """
+    typed_dict = get_typed_dict_type(typehint)
+    type_var_map = get_type_var_map(typehint, typed_dict)
+    type_var_maps = {}
+    for base in getattr(typed_dict, "__orig_bases__", ()):
+        if is_typed_dict(base):
+            for key, base_map in get_typed_dict_type_var_maps(base).items():
+                base_map = {var: substitute_type_vars(sub, type_var_map) for var, sub in base_map.items()}
+                type_var_maps[key] = base_map
+    for key in typed_dict.__annotations__:
+        type_var_maps.setdefault(key, type_var_map)
+    return type_var_maps
+
+
 def substitute_type_vars(typehint, type_var_map: dict):
     """Returns the type hint with the given TypeVars replaced by the types that they stand for."""
+    if not type_var_map:
+        return typehint
     if isinstance(typehint, TypeVar):
         return type_var_map.get(typehint, typehint)
     args = getattr(typehint, "__args__", None)
@@ -1081,7 +1111,7 @@ def substitute_type_vars(typehint, type_var_map: dict):
 def get_typed_dict_annotations(typed_dict, logger=None) -> dict:
     from ._postponed_annotations import get_global_vars, update_module_global_vars
 
-    type_var_map = get_typed_dict_type_var_map(typed_dict)
+    type_var_maps = get_typed_dict_type_var_maps(typed_dict)
     typed_dict = get_typed_dict_type(typed_dict)
 
     # Keys can be inherited from bases defined in other modules, and each key must resolve
@@ -1106,9 +1136,18 @@ def get_typed_dict_annotations(typed_dict, logger=None) -> dict:
             global_vars = {}
             update_module_global_vars(module, global_vars, logger)
         annotations.update(resolve_module_annotations(module, module_annotations, global_vars, logger))
-    if type_var_map:
-        annotations = {k: substitute_type_vars(v, type_var_map) for k, v in annotations.items()}
-    return {k: annotations[k] for k in typed_dict.__annotations__}
+    return {k: resolve_typed_dict_key_type_vars(annotations[k], type_var_maps[k]) for k in typed_dict.__annotations__}
+
+
+def resolve_typed_dict_key_type_vars(annotation, type_var_map: dict):
+    """Returns the annotation of a TypedDict key with the TypeVars in it resolved.
+
+    First the TypeVars that the subscript binds are substituted, then the ones
+    that it doesn't are replaced by what they stand for, i.e. their default,
+    constraints or bound. A TypeVar that stands for nothing is left as is, so
+    that it becomes an Unvalidated<...>, the same as for a signature parameter.
+    """
+    return replace_type_vars(substitute_type_vars(annotation, type_var_map))
 
 
 def get_typed_dict_required_keys(typed_dict, annotations: dict) -> set:
@@ -1238,7 +1277,7 @@ def adapt_typehints(
     unset_sentinel = get_parsing_setting("unset_sentinel")
 
     # Any, object and unvalidated, i.e. no validation
-    if typehint is object or typehint == Any or isinstance(typehint, UnvalidatedType):
+    if accepts_any_value(typehint):
         type_val = type(val)
         if get_registered_type(type_val) or is_subclass(type_val, Enum):
             if not serialize:  # when serializing this is done by serialize_unvalidated
@@ -1307,7 +1346,7 @@ def adapt_typehints(
         elif not serialize and not isinstance(val, type):
             path = val
             val = import_object(val)
-            if typehint in {Type, type}:
+            if typehint in {Type, type} or accepts_any_value(subtypehints[0]):
                 valid = isinstance(val, type)
             elif is_typed_dict(subtypehints[0]):
                 valid = is_typed_dict_subtype(val, subtypehints[0], logger)
@@ -1470,7 +1509,8 @@ def adapt_typehints(
             if extra_keys:
                 raise_unexpected_value(f"Unexpected keys: {extra_keys}", val)
             for k, v in val.items():
-                val[k] = adapt_typehints(v, dict_annotations[k], **adapt_kwargs)
+                # what can't be validated accepts any value, as the help shows it
+                val[k] = adapt_typehints(v, replace_unvalidatable_typehints(dict_annotations[k]), **adapt_kwargs)
         if typehint_origin is MappingProxyType and not serialize:
             val = MappingProxyType(val)
         elif typehint_origin is OrderedDict:
@@ -1825,7 +1865,9 @@ def protocol_params_match(proto_params, value_params) -> bool:
 def implements_protocol(value, protocol) -> bool:
     if not inspect.isclass(value) or value is object or not is_protocol(protocol):
         return False
-    protocol = get_protocol_origin(protocol)
+    origin = get_protocol_origin(protocol)
+    type_var_map = get_type_var_map(protocol, origin)
+    protocol = origin
 
     logger = parse_logger(True, "implements_protocol")
     members = 0
@@ -1841,6 +1883,11 @@ def implements_protocol(value, protocol) -> bool:
         except (ValueError, TypeError):
             return False
         proto_params, proto_return = get_protocol_method_signature(protocol, name, logger)
+        # a subscripted generic protocol is implemented by what its type arguments say,
+        # e.g. Proto[int] by a run(self, x: int), the same as static type checkers do
+        for param in proto_params:
+            param.annotation = substitute_type_vars(param.annotation, type_var_map)
+        proto_return = substitute_type_vars(proto_return, type_var_map)
         if not protocol_params_match(proto_params, value_params):
             return False
         if not protocol_type_matches(proto_return, value_return):
@@ -1856,11 +1903,10 @@ def get_protocol_origin(protocol):
     """Returns the protocol that a subscripted generic protocol stands for.
 
     A subscripted generic protocol, e.g. ``Proto[int]``, is a generic alias
-    through which the members can't be looked up. Its type parameters are not
-    needed either, since the TypeVars of a generic protocol are compared as
-    wildcards, see type_var_wildcard_matches.
+    through which the members can't be looked up. What it is subscripted with
+    is given by get_type_var_map, see implements_protocol.
     """
-    origin = get_typehint_origin(protocol)
+    origin = getattr(protocol, "__origin__", None)
     return origin if is_protocol(origin) else protocol
 
 
@@ -1876,16 +1922,20 @@ def is_instance_or_supports_protocol(value, class_type):
     return is_instance(value, class_type)
 
 
-def is_instance_factory_protocol(class_type, logger=None):
-    if not is_protocol(class_type):
-        return False
-    class_type = get_protocol_origin(class_type)
-    if not callable_instances(class_type):
-        return False
+def get_protocol_call_return_type(protocol, logger=None):
+    """Returns the return type of the ``__call__`` of a protocol, with its TypeVars substituted."""
     from ._postponed_annotations import get_return_type
 
-    return_type = get_return_type(class_type.__call__, logger)
-    return ActionTypeHint.is_subclass_typehint(return_type)
+    origin = get_protocol_origin(protocol)
+    # the __call__ of the origin, since for a subscripted generic protocol the alias has its own
+    return_type = get_return_type(origin.__call__, logger)
+    return substitute_type_vars(return_type, get_type_var_map(protocol, origin))
+
+
+def is_instance_factory_protocol(class_type, logger=None):
+    if not is_protocol(class_type) or not callable_instances(get_protocol_origin(class_type)):
+        return False
+    return ActionTypeHint.is_subclass_typehint(get_protocol_call_return_type(class_type, logger))
 
 
 _subclass_spec_keys = {"class_path", "init_args", "dict_kwargs", "__path__", subclasses_disabled_meta_key}
@@ -1936,9 +1986,7 @@ def subclass_spec_as_namespace(val, prev_val=None):
 def get_callable_return_type(typehint):
     return_type = None
     if is_instance_factory_protocol(typehint):
-        from ._postponed_annotations import get_return_type
-
-        return_type = get_return_type(typehint.__call__)
+        return_type = get_protocol_call_return_type(typehint)
     elif get_typehint_origin(typehint) in callable_origin_types:
         args = getattr(typehint, "__args__", None)
         if isinstance(args, tuple) and len(args) > 0:
@@ -1984,9 +2032,14 @@ def yield_class_types(typehint, is_single, also_lists=False, callable_return=Fal
         for subtype in typehint.__args__:
             yield from yield_class_types(subtype, **kwargs)
     if is_single(typehint, typehint_origin):
-        # a subscripted user defined generic, e.g. Strategy[T], is yielded as its origin
-        # class, since the consumers use the class itself, e.g. to look up its subclasses
-        yield get_generic_origin(get_typed_dict_type(typehint))
+        if is_typed_dict(typehint):
+            # a subscripted generic TypedDict is yielded as is, since its keys are
+            # resolved from it, substituting what it is subscripted with
+            yield typehint
+        else:
+            # a subscripted user defined generic, e.g. Strategy[T], is yielded as its origin
+            # class, since the consumers use the class itself, e.g. to look up its subclasses
+            yield get_generic_origin(typehint)
 
 
 def get_subclass_types(typehint, also_lists=False, callable_return=False):
@@ -2349,7 +2402,7 @@ def validate_subclass_spec_in_mapping(val, typehint, subtypehints, sub_add_kwarg
         return
     if is_typed_dict(typehint):
         return
-    if subtypehints is not None and not (subtypehints[1] == Any or isinstance(subtypehints[1], UnvalidatedType)):
+    if subtypehints is not None and not accepts_any_value(subtypehints[1]):
         return
     adapt_classes_any(deepcopy(val), typehint, False, False, sub_add_kwargs, logger)
 
@@ -2362,7 +2415,7 @@ def union_subtype_sort_key(subtype) -> int:
     of being used. Sorting is stable, thus subtypes with the same rank keep the
     relative order in which they are given.
     """
-    if subtype is object or subtype == Any or isinstance(subtype, UnvalidatedType):
+    if accepts_any_value(subtype):
         return 2  # accept any value, so nothing after them would ever be attempted
     if subtype is NoneType:
         return 1  # only accepts null, second to last so that Optional[<type>] reads as in the source code
@@ -2382,8 +2435,9 @@ def resolve_type_var_ref(type_var, ref):
     """Resolves a forward reference given as bound, constraint or PEP 696 default of a TypeVar.
 
     The reference is resolved with the names of the module in which the TypeVar
-    is defined, since that is the scope in which it was written. Unresolvable
-    references are returned unchanged, becoming an ``Unvalidated<...>``.
+    is defined, since that is the scope in which it was written. An unresolvable
+    reference becomes an ``Unvalidated<...>``, i.e. it accepts any value and the
+    help shows it as in the source code.
     """
     if not isinstance(ref, (str, ForwardRef)):
         return ref
@@ -2395,7 +2449,7 @@ def resolve_type_var_ref(type_var, ref):
         name = ref.__forward_arg__ if isinstance(ref, ForwardRef) else ref
         global_vars = get_global_vars(type_var, None)
         resolved = resolve_module_annotations(module, {"ref": name}, global_vars).get("ref", ref)
-    return ref if isinstance(resolved, (str, ForwardRef)) else resolved
+    return UnvalidatedType(ref) if isinstance(resolved, (str, ForwardRef)) else resolved
 
 
 def replace_type_var(type_var, in_type_subtype: bool):

--- a/jsonargparse/_typehints.py
+++ b/jsonargparse/_typehints.py
@@ -129,6 +129,7 @@ root_types = {
     float,
     bool,
     Any,
+    object,
     Literal,
     Type,
     type,
@@ -433,6 +434,7 @@ class ActionTypeHint(Action):
             or get_registered_type(typehint) is not None
             or is_subclass(typehint, Enum)
             or is_subclasses_disabled(typehint)
+            or is_typed_dict(typehint)
             or ActionTypeHint.is_subclass_typehint(typehint)
         )
         if full and supported:
@@ -1036,11 +1038,51 @@ def resolve_module_annotations(module: str, annotations: dict, global_vars: dict
 
 
 def is_typed_dict(typehint) -> bool:
-    return type(typehint) in typed_dict_meta_types
+    """Whether a type hint is a TypedDict, including a subscripted generic one."""
+    return type(get_typed_dict_type(typehint)) in typed_dict_meta_types
+
+
+def get_typed_dict_type(typehint):
+    """Returns the TypedDict that a subscripted generic TypedDict stands for, or the type hint unchanged.
+
+    A subscripted generic TypedDict, is a generic alias through which the keys
+    can't be looked up. Its type parameters don't change the keys, only the
+    types of the ones annotated with a TypeVar, see get_typed_dict_type_var_map.
+    """
+    origin = get_typehint_origin(typehint)
+    return origin if type(origin) in typed_dict_meta_types else typehint
+
+
+def get_typed_dict_type_var_map(typehint) -> dict:
+    """Returns the map from the TypeVars of a generic TypedDict to the types it is subscripted with."""
+    typed_dict = get_typed_dict_type(typehint)
+    if typed_dict is typehint:
+        return {}
+    parameters = getattr(typed_dict, "__parameters__", None) or ()
+    args = getattr(typehint, "__args__", None) or ()
+    return dict(zip(parameters, args))
+
+
+def substitute_type_vars(typehint, type_var_map: dict):
+    """Returns the type hint with the given TypeVars replaced by the types that they stand for."""
+    if isinstance(typehint, TypeVar):
+        return type_var_map.get(typehint, typehint)
+    args = getattr(typehint, "__args__", None)
+    # only a tuple, since e.g. types.UnionType and types.GenericAlias have __args__ as a
+    # class level slot descriptor, which is truthy but not the subtypes of an instance
+    if not isinstance(args, tuple) or not args:
+        return typehint
+    new_args = tuple(substitute_type_vars(a, type_var_map) for a in args)
+    if all(new is old for new, old in zip(new_args, args)):
+        return typehint
+    return rebuild_typehint_args(typehint, new_args)
 
 
 def get_typed_dict_annotations(typed_dict, logger=None) -> dict:
     from ._postponed_annotations import get_global_vars, update_module_global_vars
+
+    type_var_map = get_typed_dict_type_var_map(typed_dict)
+    typed_dict = get_typed_dict_type(typed_dict)
 
     # Keys can be inherited from bases defined in other modules, and each key must resolve
     # with the names of the module in which it was defined, including its TYPE_CHECKING
@@ -1064,10 +1106,13 @@ def get_typed_dict_annotations(typed_dict, logger=None) -> dict:
             global_vars = {}
             update_module_global_vars(module, global_vars, logger)
         annotations.update(resolve_module_annotations(module, module_annotations, global_vars, logger))
+    if type_var_map:
+        annotations = {k: substitute_type_vars(v, type_var_map) for k, v in annotations.items()}
     return {k: annotations[k] for k in typed_dict.__annotations__}
 
 
 def get_typed_dict_required_keys(typed_dict, annotations: dict) -> set:
+    typed_dict = get_typed_dict_type(typed_dict)
     # The totality of each class (including inheritance) is reflected in __required_keys__,
     # even when the annotations are postponed. Required and NotRequired instead may not be
     # reflected there (e.g. below Python 3.11 or with postponed annotations), so they are
@@ -1186,10 +1231,14 @@ def adapt_typehints(
     }
     subtypehints = getattr(typehint, "__args__", None)
     typehint_origin = get_typehint_origin(typehint) or typehint
+    if type(typehint_origin) in typed_dict_meta_types:
+        # a subscripted generic TypedDict is validated as its unsubscripted form, see get_typed_dict_type
+        subtypehints = None
+        typehint_origin = dict
     unset_sentinel = get_parsing_setting("unset_sentinel")
 
-    # Any and unvalidated, i.e. no validation
-    if typehint == Any or isinstance(typehint, UnvalidatedType):
+    # Any, object and unvalidated, i.e. no validation
+    if typehint is object or typehint == Any or isinstance(typehint, UnvalidatedType):
         type_val = type(val)
         if get_registered_type(type_val) or is_subclass(type_val, Enum):
             if not serialize:  # when serializing this is done by serialize_unvalidated
@@ -1776,6 +1825,7 @@ def protocol_params_match(proto_params, value_params) -> bool:
 def implements_protocol(value, protocol) -> bool:
     if not inspect.isclass(value) or value is object or not is_protocol(protocol):
         return False
+    protocol = get_protocol_origin(protocol)
 
     logger = parse_logger(True, "implements_protocol")
     members = 0
@@ -1802,6 +1852,18 @@ def is_protocol(class_type) -> bool:
     return getattr(class_type, "_is_protocol", False)
 
 
+def get_protocol_origin(protocol):
+    """Returns the protocol that a subscripted generic protocol stands for.
+
+    A subscripted generic protocol, e.g. ``Proto[int]``, is a generic alias
+    through which the members can't be looked up. Its type parameters are not
+    needed either, since the TypeVars of a generic protocol are compared as
+    wildcards, see type_var_wildcard_matches.
+    """
+    origin = get_typehint_origin(protocol)
+    return origin if is_protocol(origin) else protocol
+
+
 def is_subclass_or_implements_protocol(value, class_type) -> bool:
     if is_protocol(class_type):
         return implements_protocol(value, class_type)
@@ -1815,7 +1877,10 @@ def is_instance_or_supports_protocol(value, class_type):
 
 
 def is_instance_factory_protocol(class_type, logger=None):
-    if not is_protocol(class_type) or not callable_instances(class_type):
+    if not is_protocol(class_type):
+        return False
+    class_type = get_protocol_origin(class_type)
+    if not callable_instances(class_type):
         return False
     from ._postponed_annotations import get_return_type
 
@@ -1888,6 +1953,7 @@ def is_single_class_type(typehint, typehint_origin, closed_class):
             or (is_generic_class(typehint) and inspect.isclass(typehint.__origin__))
         )
         and typehint not in leaf_or_root_types
+        and not is_typed_dict(typehint)
         and not get_registered_type(typehint)
         and not is_pydantic_type(typehint)
         and not is_subclass(typehint, (Path, Enum))
@@ -1920,7 +1986,7 @@ def yield_class_types(typehint, is_single, also_lists=False, callable_return=Fal
     if is_single(typehint, typehint_origin):
         # a subscripted user defined generic, e.g. Strategy[T], is yielded as its origin
         # class, since the consumers use the class itself, e.g. to look up its subclasses
-        yield get_generic_origin(typehint)
+        yield get_generic_origin(get_typed_dict_type(typehint))
 
 
 def get_subclass_types(typehint, also_lists=False, callable_return=False):
@@ -2108,7 +2174,7 @@ def adapt_class_type(
 ):
     prev_val = subclass_spec_as_namespace(prev_val)
     value = subclass_spec_as_namespace(value)
-    if is_generic_class(typehint):
+    if is_generic_class(typehint) and not is_protocol(typehint):
         val_class = typehint
     else:
         val_class = import_object(value.class_path)
@@ -2144,14 +2210,17 @@ def adapt_class_type(
             return value
 
         instantiator_fn = get_class_instantiator()
+        # only the top level keys, since a value can be a namespace, e.g. a subclass spec
+        # kept as is for an Any typed parameter, which must not be expanded into kwargs
+        init_kwargs = dict(init_args.items(branches=True, nested=False))
 
         if partial_skip_args:
             return partial(
                 instantiator_fn,
                 val_class,
-                **{**init_args, **dict_kwargs},
+                **{**init_kwargs, **dict_kwargs},
             )
-        return instantiator_fn(val_class, **{**init_args, **dict_kwargs})
+        return instantiator_fn(val_class, **{**init_kwargs, **dict_kwargs})
 
     prev_init_args = prev_val.get("init_args") if isinstance(prev_val, Namespace) else None
 
@@ -2293,22 +2362,40 @@ def union_subtype_sort_key(subtype) -> int:
     of being used. Sorting is stable, thus subtypes with the same rank keep the
     relative order in which they are given.
     """
-    if subtype == Any or isinstance(subtype, UnvalidatedType):
-        return 3  # accept any value, so nothing after them would ever be attempted
+    if subtype is object or subtype == Any or isinstance(subtype, UnvalidatedType):
+        return 2  # accept any value, so nothing after them would ever be attempted
     if subtype is NoneType:
-        return 2  # only accepts null, second to last so that Optional[<type>] reads as in the source code
-    if subtype is object:
-        return 1  # accepts the import path of any class, so no class subtype after it would be attempted
+        return 1  # only accepts null, second to last so that Optional[<type>] reads as in the source code
     return 0
 
 
 def get_type_var_default(type_var):
     """Returns the PEP 696 default of a TypeVar, or None when it has none."""
     if getattr(type_var, "has_default", lambda: False)():
-        default = type_var.__default__
+        default = resolve_type_var_ref(type_var, type_var.__default__)
         if default is not None:
             return default
     return None
+
+
+def resolve_type_var_ref(type_var, ref):
+    """Resolves a forward reference given as bound, constraint or PEP 696 default of a TypeVar.
+
+    The reference is resolved with the names of the module in which the TypeVar
+    is defined, since that is the scope in which it was written. Unresolvable
+    references are returned unchanged, becoming an ``Unvalidated<...>``.
+    """
+    if not isinstance(ref, (str, ForwardRef)):
+        return ref
+    from ._postponed_annotations import get_global_vars
+
+    resolved = ref
+    module = getattr(type_var, "__module__", None)
+    if isinstance(module, str):
+        name = ref.__forward_arg__ if isinstance(ref, ForwardRef) else ref
+        global_vars = get_global_vars(type_var, None)
+        resolved = resolve_module_annotations(module, {"ref": name}, global_vars).get("ref", ref)
+    return ref if isinstance(resolved, (str, ForwardRef)) else resolved
 
 
 def replace_type_var(type_var, in_type_subtype: bool):
@@ -2322,9 +2409,9 @@ def replace_type_var(type_var, in_type_subtype: bool):
     if default is not None:
         return default
     if type_var.__constraints__:
-        return Union[type_var.__constraints__]
+        return Union[tuple(resolve_type_var_ref(type_var, c) for c in type_var.__constraints__)]
     if type_var.__bound__:
-        return type_var.__bound__
+        return resolve_type_var_ref(type_var, type_var.__bound__)
     return object if in_type_subtype else type_var
 
 
@@ -2484,7 +2571,7 @@ def type_to_str(obj):
     if obj in type_expression_types:
         return type_expression_types[obj]
     # is_subclass not used, since in python<3.12 it considers an Annotated a subclass of its origin type
-    if obj in {bool, tuple} or (isinstance(obj, type) and issubclass(obj, (int, float, str, Path, Enum))):
+    if obj in {bool, tuple, object} or (isinstance(obj, type) and issubclass(obj, (int, float, str, Path, Enum))):
         return obj.__name__
     return typehint_to_str(obj)
 

--- a/jsonargparse_tests/test_link_arguments.py
+++ b/jsonargparse_tests/test_link_arguments.py
@@ -13,6 +13,7 @@ from jsonargparse import (
     Namespace,
     add_instantiator,
     lazy_instance,
+    set_parsing_settings,
 )
 from jsonargparse._optionals import docstring_parser_support
 from jsonargparse_tests.conftest import get_parse_args_stdout, get_parser_help, json_or_yaml_dump, json_or_yaml_load
@@ -368,7 +369,9 @@ class ClassD:
         """ClassD title"""
 
 
-def test_on_parse_add_subclass_arguments_compute_fn_return_dict(parser):
+def test_on_parse_add_subclass_arguments_compute_fn_return_dict(parser, parsing_settings_patch):
+    set_parsing_settings(instantiate_subclass_spec_in_any=False)
+
     def return_dict(value: dict):
         return value
 
@@ -389,6 +392,7 @@ def test_on_parse_add_subclass_arguments_compute_fn_return_dict(parser):
     cfg = parser.parse_args([f"--d={json.dumps(d_value)}", f"--c={json.dumps(c_value)}"])
     assert cfg.d.init_args.a1 == c_value
     assert cfg.d.init_args.a2 == c_value
+    assert cfg.d.init_args.a3 == Namespace(**{**c_value, "init_args": Namespace(p=3)})
 
     init = parser.instantiate(cfg)
     assert isinstance(init.d, ClassD)

--- a/jsonargparse_tests/test_parsing_settings.py
+++ b/jsonargparse_tests/test_parsing_settings.py
@@ -519,6 +519,34 @@ def test_validate_subclass_spec_in_any_enabled_non_subclass_dict_kept(parser):
     assert cfg.any == {"a": 0, "b": 1}
 
 
+# validate_subclass_spec_in_any for object, which like Any accepts any value
+
+
+def test_validate_subclass_spec_in_any_object_disabled_kept(parser):
+    parser.add_argument("--obj", type=object)
+
+    cfg = parser.parse_args(['--obj={"class_path": "nonexistent.Foo"}'])
+    assert cfg.obj == {"class_path": "nonexistent.Foo"}
+
+
+def test_validate_subclass_spec_in_any_object_enabled_fails(parser):
+    set_parsing_settings(validate_subclass_spec_in_any=True)
+    parser.add_argument("--obj", type=object)
+
+    with pytest.raises(ArgumentError, match="Invalid subclass spec given as value for type object"):
+        parser.parse_args(['--obj={"class_path": "nonexistent.Foo"}'])
+
+
+def test_validate_subclass_spec_in_any_enabled_union_object_fails(parser):
+    set_parsing_settings(validate_subclass_spec_in_any=True)
+    parser.add_argument("--union", type=Optional[Union[AnySubclass, object]])
+
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args([f'--union={{"class_path": "{__name__}.AnySubclass", "init_args": {{"nope": 1}}}}'])
+    ctx.match("Does not validate against any of the Union subtypes")
+    ctx.match("Invalid subclass spec given as value for type object")
+
+
 # validate_subclass_spec_in_any for dict types that accept any value
 
 unvalidated_dict_type = Dict[str, UnvalidatedType("some.SomeType")]  # type: ignore[misc,valid-type]
@@ -656,6 +684,45 @@ def test_instantiate_subclass_spec_in_any_disabled(parser):
     assert init.any == any_subclass_namespace
 
     assert json_or_yaml_load(parser.dump(cfg)) == {"any": any_subclass_spec}
+
+
+def test_instantiate_subclass_spec_in_any_object(parser):
+    set_parsing_settings(instantiate_subclass_spec_in_any=True)
+    parser.add_argument("--obj", type=object)
+
+    cfg = parser.parse_args([f"--obj={json.dumps(any_subclass_spec)}"])
+    assert cfg.obj == any_subclass_namespace
+    init = parser.instantiate(cfg)
+    assert isinstance(init.obj, AnySubclass)
+    assert init.obj.p == 3
+
+
+def test_instantiate_subclass_spec_in_any_object_disabled(parser):
+    set_parsing_settings(instantiate_subclass_spec_in_any=False)
+    parser.add_argument("--obj", type=object)
+
+    cfg = parser.parse_args([f"--obj={json.dumps(any_subclass_spec)}"])
+    init = parser.instantiate(cfg)
+    assert init.obj == any_subclass_namespace
+    assert json_or_yaml_load(parser.dump(cfg)) == {"obj": any_subclass_spec}
+
+
+class AnyInitArg:
+    def __init__(self, a: Any = None):
+        self.a = a
+
+
+def test_instantiate_subclass_spec_in_any_disabled_as_init_arg(parser):
+    set_parsing_settings(instantiate_subclass_spec_in_any=False)
+    parser.add_subclass_arguments(AnyInitArg, "cls")
+
+    spec = {"class_path": f"{__name__}.AnyInitArg", "init_args": {"a": any_subclass_spec}}
+    cfg = parser.parse_args([f"--cls={json.dumps(spec)}"])
+    assert cfg.cls.init_args.a == any_subclass_namespace
+
+    init = parser.instantiate(cfg)
+    assert isinstance(init.cls, AnyInitArg)
+    assert init.cls.a == any_subclass_namespace
 
 
 def test_instantiate_subclass_spec_in_any_disabled_nested_in_list_and_dict(parser):

--- a/jsonargparse_tests/test_parsing_settings.py
+++ b/jsonargparse_tests/test_parsing_settings.py
@@ -550,7 +550,7 @@ def test_validate_subclass_spec_in_any_enabled_union_object_fails(parser):
 # validate_subclass_spec_in_any for dict types that accept any value
 
 unvalidated_dict_type = Dict[str, UnvalidatedType("some.SomeType")]  # type: ignore[misc,valid-type]
-any_dict_types = [dict, Dict, Dict[str, Any], unvalidated_dict_type]
+any_dict_types = [dict, Dict, Dict[str, Any], Dict[str, object], unvalidated_dict_type]
 
 
 @pytest.mark.parametrize("dict_type", any_dict_types)
@@ -624,16 +624,18 @@ def test_validate_subclass_spec_in_any_enabled_typed_dict_unaffected(parser):
     assert cfg.dict == {"class_path": "nonexistent.Foo"}
 
 
-def test_validate_subclass_spec_in_any_disabled_union_dict_swallows(parser):
-    parser.add_argument("--union", type=Optional[Union[AnySubclass, Dict[str, Any]]])
+@pytest.mark.parametrize("dict_type", [Dict[str, Any], Dict[str, object]])
+def test_validate_subclass_spec_in_any_disabled_union_dict_swallows(parser, dict_type):
+    parser.add_argument("--union", type=Optional[Union[AnySubclass, dict_type]])
 
     cfg = parser.parse_args([f'--union={{"class_path": "{__name__}.AnySubclass", "init_args": {{"nope": 1}}}}'])
     assert cfg.union == {"class_path": f"{__name__}.AnySubclass", "init_args": {"nope": 1}}
 
 
-def test_validate_subclass_spec_in_any_enabled_union_dict_fails(parser):
+@pytest.mark.parametrize("dict_type", [Dict[str, Any], Dict[str, object]])
+def test_validate_subclass_spec_in_any_enabled_union_dict_fails(parser, dict_type):
     set_parsing_settings(validate_subclass_spec_in_any=True)
-    parser.add_argument("--union", type=Optional[Union[AnySubclass, Dict[str, Any]]])
+    parser.add_argument("--union", type=Optional[Union[AnySubclass, dict_type]])
 
     with pytest.raises(ArgumentError) as ctx:
         parser.parse_args([f'--union={{"class_path": "{__name__}.AnySubclass", "init_args": {{"nope": 1}}}}'])

--- a/jsonargparse_tests/test_postponed_annotations.py
+++ b/jsonargparse_tests/test_postponed_annotations.py
@@ -331,6 +331,9 @@ def test_typed_dict_unresolvable_key_type(parser):
     parser.add_argument("--opts", type=UnresolvableTypedDict)
     cfg = parser.parse_args(['--opts={"num": 1}'])
     assert cfg.opts == {"num": 1}
+    # being unresolved, the key accepts any value without validation
+    cfg = parser.parse_args(['--opts={"num": 1, "typo": {"x": [1, 2]}}'])
+    assert cfg.opts == {"num": 1, "typo": {"x": [1, 2]}}
 
 
 class UnresolvableTypedDictClass:

--- a/jsonargparse_tests/test_pydantic.py
+++ b/jsonargparse_tests/test_pydantic.py
@@ -860,9 +860,16 @@ def test_pydantic_alias_of_group_field_skipped(parser, logger):
         parser.add_class_arguments(AliasVariants, "m", sub_configs=True)
     assert 'Skipping aliases of parameter "nested"' in logs.getvalue()
     assert "not supported for subclasses-disabled types added as a group" in logs.getvalue()
-    assert parser.parse_args(["--m.nested.alias_name=abc"]).m.nested == Namespace(attr_name="abc")
-    with pytest.raises(ArgumentError, match="unrecognized arguments: --m.nest.alias_name=abc"):
-        parser.parse_args(["--m.nest.alias_name=abc"])
+
+    with capture_logs(logger) as logs:
+        cfg = parser.parse_args(["--m.nested.alias_name=abc"])
+    assert cfg.m.nested == Namespace(attr_name="abc")
+    assert "Parsed command line arguments" in logs.getvalue()
+
+    with capture_logs(logger) as logs:
+        with pytest.raises(ArgumentError, match="unrecognized arguments: --m.nest.alias_name=abc"):
+            parser.parse_args(["--m.nest.alias_name=abc"])
+    assert "unrecognized arguments: --m.nest.alias_name=abc" in logs.getvalue()
 
 
 @skip_if_pydantic_v1
@@ -873,4 +880,8 @@ def test_pydantic_alias_conflicting_with_added_argument_skipped(parser, logger):
         parser.add_class_arguments(AliasVariants, "m", sub_configs=True)
     assert 'Skipping aliases of parameter "elems"' in logs.getvalue()
     assert "conflicts with an already added argument" in logs.getvalue()
-    assert parser.parse_args(["--m.el=3"]).m.el == 3
+
+    with capture_logs(logger) as logs:
+        cfg = parser.parse_args(["--m.el=3"])
+    assert cfg.m.el == 3
+    assert "Parsed command line arguments" in logs.getvalue()

--- a/jsonargparse_tests/test_shtab.py
+++ b/jsonargparse_tests/test_shtab.py
@@ -13,7 +13,7 @@ from enum import Enum
 from importlib.util import find_spec
 from os import PathLike
 from pathlib import Path
-from typing import Any, Callable, Literal, Optional, TypedDict, Union
+from typing import Any, Callable, Generic, Literal, Optional, TypedDict, TypeVar, Union
 from unittest.mock import patch
 
 import pytest
@@ -104,6 +104,32 @@ def test_bash_any(parser, subtests):
         parser,
         [
             ("any", Any, "", [], None),
+        ],
+    )
+
+
+def test_bash_object(parser, subtests):
+    parser.add_argument("--obj", type=object)
+    assert_bash_typehint_completions(
+        subtests,
+        parser,
+        [
+            ("obj", object, "", [], None),
+        ],
+    )
+
+
+@pytest.mark.parametrize("any_type", [Any, object])
+def test_bash_union_literal_and_any(parser, any_type, subtests):
+    typehint = Union[Literal["one", "two"], any_type]
+    parser.add_argument("--union", type=typehint)
+    # the choices are not all that is accepted, so a prefix is required to complete them
+    assert_bash_typehint_completions(
+        subtests,
+        parser,
+        [
+            ("union", typehint, "", [], None),
+            ("union", typehint, "t", ["two"], "1/2"),
         ],
     )
 
@@ -583,6 +609,25 @@ def test_bash_typed_dict_help_choices(parser):
     shtab_script = get_shtab_script(parser, "bash")
     choices = get_bash_array(shtab_script, "_shtab_tool___area_help_choices")
     assert choices == ["AreaDict", f"{__name__}.Base", f"{__name__}.SubA", f"{__name__}.SubB"]
+
+
+PointVar = TypeVar("PointVar")
+
+if sys.version_info >= (3, 11):  # a generic TypedDict requires python 3.11 or later
+
+    class PointDict(TypedDict, Generic[PointVar]):
+        x: PointVar
+        y: PointVar
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="generic TypedDict introduced in python 3.11")
+def test_bash_subscripted_typed_dict_help_choices(parser):
+    parser.add_argument("--point", type=Union[PointDict[int], Base])
+    shtab_script = get_shtab_script(parser, "bash")
+    choices = get_bash_array(shtab_script, "_shtab_tool___point_help_choices")
+    assert choices == ["PointDict", f"{__name__}.Base", f"{__name__}.SubA", f"{__name__}.SubB"]
+    options = get_bash_array(shtab_script, "_shtab_tool_option_strings")
+    assert {"--point", "--point.x", "--point.y"}.issubset(options)
 
 
 class OptionsDict(TypedDict, total=False):

--- a/jsonargparse_tests/test_shtab.py
+++ b/jsonargparse_tests/test_shtab.py
@@ -62,6 +62,18 @@ def get_bash_array(shtab_script, name):
     return shlex.split(match.group(1))
 
 
+def get_zsh_completion_actions(shtab_script):
+    """Completion action of each zsh option spec, independent of the message shtab puts in it.
+
+    A zsh option spec is ``"--opt[description]:message:action"``. Older shtab versions use the
+    action's dest as message, newer ones its metavar when there is one.
+    """
+    actions = {}
+    for match in re.finditer(r'^\s*"(--[^\[]+)\[.*\]:([^:]*):(.*)"$', shtab_script, re.MULTILINE):
+        actions[match.group(1)] = match.group(3)
+    return actions
+
+
 def is_positional(dest, parser):
     if parser is not None:
         action = next(a for a in parser._actions if a.dest == dest)
@@ -826,11 +838,12 @@ def test_zsh_script(parser):
     parser.add_argument("--path", type=PathLike)
     parser.add_argument("--cls", type=Base)
     shtab_script = get_shtab_script(parser, "zsh")
-    assert ":enum:(ABC XY XZ null)" in shtab_script
-    assert ":path:_files" in shtab_script
+    actions = get_zsh_completion_actions(shtab_script)
     classes = f"{__name__}.Base {__name__}.SubA {__name__}.SubB"
-    assert f":cls.help:({classes})" in shtab_script
-    assert f":cls:({classes})" in shtab_script
-    assert ":cls.p1:" in shtab_script
-    assert ":cls.p2:(ABC XY XZ)" in shtab_script
-    assert ":cls.p3:" in shtab_script
+    assert actions["--enum"] == "(ABC XY XZ null)"
+    assert actions["--path"] == "_files"
+    assert actions["--cls.help"] == f"({classes})"
+    assert actions["--cls"] == f"({classes})"
+    assert actions["--cls.p1"] == ""
+    assert actions["--cls.p2"] == "(ABC XY XZ)"
+    assert actions["--cls.p3"] == ""

--- a/jsonargparse_tests/test_signatures.py
+++ b/jsonargparse_tests/test_signatures.py
@@ -504,6 +504,26 @@ def test_add_class_generics(parser):
     assert cfg.p == Namespace(a=5, b=6 + 7j)
 
 
+class WithGenericsDocstring(Generic[X]):
+    """Class with generics.
+
+    Args:
+        a: The a doc.
+    """
+
+    def __init__(self, a: Optional[X] = None):  # pragma: no cover
+        self.a = a
+
+
+@skip_if_docstring_parser_unavailable
+def test_add_class_generics_docstring(parser):
+    parser.add_class_arguments(WithGenericsDocstring[int], "p")
+    # the docstring of a subscripted generic is the one of the class that it stands for
+    help_str = get_parser_help(parser, strip=True)
+    assert "Class with generics:" in help_str
+    assert "--p.a A The a doc. (type:" in help_str
+
+
 class WithGenericsPep604Union(Generic[X]):
     def __init__(self, a: X | None = None, b: int | None = None):  # pragma: no cover
         self.a = a

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -37,6 +37,7 @@ from jsonargparse import (
     Namespace,
     add_instantiator,
     lazy_instance,
+    set_parsing_settings,
 )
 from jsonargparse._instantiation import _global_class_instantiators
 from jsonargparse._typehints import _cached_class_parsers, implements_protocol, is_instance_or_supports_protocol
@@ -979,7 +980,8 @@ class AnySubclasses:
         self.obj2 = obj2
 
 
-def test_type_any_subclasses(parser):
+def test_type_any_subclasses(parser, parsing_settings_patch):
+    set_parsing_settings(instantiate_subclass_spec_in_any=True)
     parser.add_argument("--any", type=Any)
     value = {
         "class_path": f"{__name__}.AnySubclasses",
@@ -1019,7 +1021,8 @@ def test_type_any_subclasses(parser):
     assert isinstance(cfg.any, dict)
 
 
-def test_type_any_list_of_subclasses(parser):
+def test_type_any_list_of_subclasses(parser, parsing_settings_patch):
+    set_parsing_settings(instantiate_subclass_spec_in_any=True)
     parser.add_argument("--any", type=Any)
     value = [
         {
@@ -1042,7 +1045,8 @@ def test_type_any_list_of_subclasses(parser):
     assert 2 == init.any[1].p
 
 
-def test_type_any_dict_of_subclasses(parser):
+def test_type_any_dict_of_subclasses(parser, parsing_settings_patch):
+    set_parsing_settings(instantiate_subclass_spec_in_any=True)
     parser.add_argument("--any", type=Any)
     value = {
         "k1": {
@@ -2037,6 +2041,31 @@ def test_implements_generic_protocol(expected, protocol, value):
 
 def test_parse_implements_generic_protocol(parser):
     parser.add_argument("--cls", type=GenericInterface)
+    cfg = parser.parse_args([f"--cls={__name__}.GenericImplementsOwnTypeVar"])
+    assert cfg.cls.class_path == f"{__name__}.GenericImplementsOwnTypeVar"
+    init = parser.instantiate(cfg)
+    assert isinstance(init.cls, GenericImplementsOwnTypeVar)
+    with pytest.raises(ArgumentError, match="does not implement protocol"):
+        parser.parse_args([f"--cls={__name__}.GenericNotImplements"])
+
+
+@pytest.mark.parametrize(
+    "expected, protocol, value",
+    [
+        (True, GenericInterface[int], GenericImplementsOwnTypeVar),
+        (True, GenericInterface[int], GenericImplementsConcrete),
+        (False, GenericInterface[int], GenericNotImplements),
+        (False, GenericInterface[str], GenericNotAcceptsNone),
+        (True, GenericPairInterface[str], GenericPairImplements),
+        (False, GenericPairInterface[str], GenericPairNotImplements),
+    ],
+)
+def test_implements_subscripted_generic_protocol(expected, protocol, value):
+    assert implements_protocol(value, protocol) is expected
+
+
+def test_parse_implements_subscripted_generic_protocol(parser):
+    parser.add_argument("--cls", type=GenericInterface[int])
     cfg = parser.parse_args([f"--cls={__name__}.GenericImplementsOwnTypeVar"])
     assert cfg.cls.class_path == f"{__name__}.GenericImplementsOwnTypeVar"
     init = parser.instantiate(cfg)

--- a/jsonargparse_tests/test_subclasses.py
+++ b/jsonargparse_tests/test_subclasses.py
@@ -2053,10 +2053,14 @@ def test_parse_implements_generic_protocol(parser):
     "expected, protocol, value",
     [
         (True, GenericInterface[int], GenericImplementsOwnTypeVar),
+        (True, GenericInterface[str], GenericImplementsOwnTypeVar),
         (True, GenericInterface[int], GenericImplementsConcrete),
+        # the type arguments are substituted, so an int implementation is not a GenericInterface[str]
+        (False, GenericInterface[str], GenericImplementsConcrete),
         (False, GenericInterface[int], GenericNotImplements),
         (False, GenericInterface[str], GenericNotAcceptsNone),
         (True, GenericPairInterface[str], GenericPairImplements),
+        (False, GenericPairInterface[int], GenericPairImplements),
         (False, GenericPairInterface[str], GenericPairNotImplements),
     ],
 )
@@ -2072,6 +2076,12 @@ def test_parse_implements_subscripted_generic_protocol(parser):
     assert isinstance(init.cls, GenericImplementsOwnTypeVar)
     with pytest.raises(ArgumentError, match="does not implement protocol"):
         parser.parse_args([f"--cls={__name__}.GenericNotImplements"])
+
+
+def test_parse_subscripted_generic_protocol_type_argument_mismatch(parser):
+    parser.add_argument("--cls", type=GenericInterface[str])
+    with pytest.raises(ArgumentError, match="does not implement protocol"):
+        parser.parse_args([f"--cls={__name__}.GenericImplementsConcrete"])
 
 
 class MultipleMethodsInterface(Protocol):

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -240,6 +240,27 @@ def test_type_any(parser):
     assert "[[[" == parser.parse_args(["--any=[[["]).any
 
 
+@parser_modes
+def test_type_object(parser):
+    # object is the top of the class hierarchy, thus like Any it accepts any value
+    parser.add_argument("--obj", type=object)
+    assert "abc" == parser.parse_args(["--obj=abc"]).obj
+    assert 123 == parser.parse_args(["--obj=123"]).obj
+    assert 5.6 == parser.parse_args(["--obj=5.6"]).obj
+    assert [7, 8] == parser.parse_args(["--obj=[7, 8]"]).obj
+    assert {"a": 0, "b": 1} == parser.parse_args(['--obj={"a":0, "b":1}']).obj
+    assert True is parser.parse_args(["--obj=true"]).obj
+    assert None is parser.parse_args(["--obj=null"]).obj
+
+
+def test_type_object_dump(parser):
+    parser.add_argument("--obj", type=object, default=EnumABC.B)
+    cfg = parser.parse_args([])
+    with assert_dump_warnings(serialized_as("EnumABC", "str")):
+        dump = parser.dump(cfg)
+    assert {"obj": "B"} == json_or_yaml_load(dump)
+
+
 @contextmanager
 def assert_dump_warnings(*expected):
     """Asserts that the dump gives exactly one warning containing each of the given fragments."""
@@ -468,6 +489,22 @@ class TypeVarOptions(TypedDict, total=False):
 
 BoundTypedDictVar = TypeVar("BoundTypedDictVar", bound=TypeVarOptions)
 
+GenericVar = TypeVar("GenericVar")
+
+# a generic TypedDict requires python 3.11 or later, or typing_extensions
+generic_typed_dict_support = sys.version_info >= (3, 11)
+skip_if_no_generic_typed_dict = pytest.mark.skipif(
+    not generic_typed_dict_support, reason="generic TypedDict introduced in python 3.11"
+)
+
+if generic_typed_dict_support:
+
+    class GenericOptions(TypedDict, Generic[GenericVar], total=False):
+        temperature: float
+        stop: List[str]
+        extra: GenericVar
+        extras: List[GenericVar]
+
 
 def test_typevar_bound_argument(parser):
     parser.add_argument("--options", type=Optional[BoundTypedDictVar])
@@ -513,6 +550,51 @@ def test_typevar_default_argument(parser):
     assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
     pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"unknown": 1}']))
     assert f"(type: {type_to_str(Optional[TypeVarOptions])}, default: null)" in get_parser_help(parser)
+
+
+@pytest.mark.skipif(not typing_extensions_support, reason="typing_extensions package is required")
+def test_typevar_default_forward_ref(parser):
+    from typing_extensions import TypeVar as TypeVarExt
+
+    default_var = TypeVarExt("default_var", bound=Mapping[str, Any], default="TypeVarOptions")
+    parser.add_argument("--options", type=Optional[default_var])
+    assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
+    pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"unknown": 1}']))
+    assert f"(type: {type_to_str(Optional[TypeVarOptions])}, default: null)" in get_parser_help(parser)
+
+
+@pytest.mark.skipif(not typing_extensions_support, reason="typing_extensions package is required")
+@skip_if_no_generic_typed_dict
+def test_typevar_default_forward_ref_subscripted_generic_typeddict(parser):
+    from typing_extensions import TypeVar as TypeVarExt
+
+    default_var = TypeVarExt("default_var", bound=Mapping[str, Any], default="GenericOptions[int]")
+    parser.add_argument("--options", type=Optional[default_var])
+    assert parser.parse_args(['--options={"extra": 1}']).options == {"extra": 1}
+    pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"extra": "x"}']))
+    help_str = get_parser_help(parser)
+    assert f"(type: {type_to_str(Optional[GenericOptions[int]])}, default: null)" in help_str
+    assert "Unvalidated" not in help_str
+
+
+def test_typevar_unresolvable_forward_ref(parser):
+    parser.add_function_arguments(function_typevar_unresolvable_bound, "x")
+    assert parser.parse_args(['--x.options={"anything": 1}']).x.options == {"anything": 1}
+    assert "Unvalidated<MisspelledOptions>" in get_parser_help(parser)
+
+
+UnresolvableBoundVar = TypeVar("UnresolvableBoundVar", bound="MisspelledOptions")  # type: ignore[name-defined]  # noqa: F821
+
+
+def function_typevar_unresolvable_bound(options: Optional[UnresolvableBoundVar] = None):
+    pass  # pragma: no cover
+
+
+def test_typevar_bound_forward_ref(parser):
+    bound_var = TypeVar("bound_var", bound="TypeVarOptions")
+    parser.add_argument("--options", type=Optional[bound_var])
+    assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
+    pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"unknown": 1}']))
 
 
 # enum tests
@@ -1026,6 +1108,53 @@ def test_typeddict_with_not_required_arg(parser):
 @pytest.mark.skipif(not Required, reason="Required introduced in python 3.11 or backported in typing_extensions")
 def test_required_support():
     assert ActionTypeHint.is_supported_typehint(Required[Any])
+
+
+# subscripted generic TypedDict tests
+
+
+@skip_if_no_generic_typed_dict
+def test_subscripted_generic_typeddict(parser):
+    parser.add_argument("--options", type=Optional[GenericOptions[int]])
+    assert parser.parse_args(['--options={"temperature": 0.5, "stop": ["x"], "extra": 1, "extras": [2]}']).options == {
+        "temperature": 0.5,
+        "stop": ["x"],
+        "extra": 1,
+        "extras": [2],
+    }
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--options={"unknown": 1}'])
+    ctx.match("Unexpected keys")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--options={"extra": "x"}'])
+    ctx.match("Expected a <class 'int'>")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--options={"extras": ["x"]}'])
+    ctx.match("Expected a <class 'int'>")
+    assert f"(type: {type_to_str(Optional[GenericOptions[int]])}, default: null)" in get_parser_help(parser)
+
+
+def test_subscripted_non_generic_typeddict(parser):
+    parser.add_argument("--options", type=Optional[TypeVarOptions[None]])
+    assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--options={"unknown": 1}'])
+    ctx.match("Unexpected keys")
+    assert f"(type: {type_to_str(Optional[TypeVarOptions[None]])}, default: null)" in get_parser_help(parser)
+
+
+@pytest.mark.skipif(not typing_extensions_support, reason="typing_extensions package is required")
+@skip_if_no_generic_typed_dict
+def test_typevar_default_subscripted_generic_typeddict(parser):
+    from typing_extensions import TypeVar as TypeVarExt
+
+    options_var = TypeVarExt("options_var", bound=Mapping[str, Any], default=GenericOptions[int])
+    parser.add_argument("--options", type=Optional[options_var])
+    assert parser.parse_args(['--options={"extra": 1}']).options == {"extra": 1}
+    pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"unknown": 1}']))
+    help_str = get_parser_help(parser)
+    assert f"(type: {type_to_str(Optional[GenericOptions[int]])}, default: null)" in help_str
+    assert "Unvalidated" not in help_str
 
 
 @pytest.mark.skipif(not Required, reason="Required introduced in python 3.11 or backported in typing_extensions")
@@ -1916,8 +2045,9 @@ unvalidated_type = UnvalidatedType("some.SomeType")
             "int | Any | Unvalidated<SomeType>",
         ),
         (Union[str, Any], "Union[str, Any]", "str | Any"),
-        # object last, since it accepts the import path of any class
+        # object last, since like Any it accepts any value
         (Union[object, int], "Union[int, object]", "int | object"),
+        (Union[object, None], "Optional[object]", "null | object"),
         # None second to last, so that Optional keeps its form
         (Optional[str], "Optional[str]", "str | null"),
         (Optional[int], "Optional[int]", "int | null"),
@@ -1952,7 +2082,7 @@ def test_union_subtypes_sorted_on_add_argument(parser, typehint, expected, expec
     [
         (object | int, "int | object"),
         (int | None, "int | null"),
-        (object | int | None, "int | object | null"),
+        (object | int | None, "int | null | object"),
         (list[object | int], "list[int | object]"),
     ],
     ids=str,
@@ -1964,7 +2094,9 @@ def test_union_subtypes_sorted_new_syntax(parser, typehint, expected):
     assert type_to_str(action._typehint) == expected
 
 
-@pytest.mark.parametrize("typehint", [Union[unvalidated_type, EnumABC], Union[Any, EnumABC]], ids=str)
+@pytest.mark.parametrize(
+    "typehint", [Union[unvalidated_type, EnumABC], Union[Any, EnumABC], Union[object, EnumABC]], ids=str
+)
 def test_union_subtypes_sorted_accept_any_last_parse(parser, typehint):
     # without the sorting the value would be accepted as is by the first subtype
     parser.add_argument("--val", type=typehint)

--- a/jsonargparse_tests/test_typehints.py
+++ b/jsonargparse_tests/test_typehints.py
@@ -28,6 +28,7 @@ from typing import (
     FrozenSet,
     Generic,
     Iterable,
+    Iterator,
     List,
     Literal,
     Mapping,
@@ -444,6 +445,21 @@ def test_type_typehint_with_arg(parser):
     pytest.raises(ArgumentError, lambda: parser.parse_args(["--cls=uuid.UUID"]))
 
 
+def test_type_typehint_any_arg(parser):
+    parser.add_argument("--cls", type=type[Any])
+    # every class is a type[Any], the same as for type without an argument
+    cfg = parser.parse_args(["--cls=uuid.UUID"])
+    assert cfg.cls is uuid.UUID
+    assert json_or_yaml_load(parser.dump(cfg)) == {"cls": "uuid.UUID"}
+    pytest.raises(ArgumentError, lambda: parser.parse_args(["--cls=time.time"]))
+
+
+def test_type_typehint_object_arg(parser):
+    parser.add_argument("--cls", type=type[object])
+    assert parser.parse_args(["--cls=uuid.UUID"]).cls is uuid.UUID
+    pytest.raises(ArgumentError, lambda: parser.parse_args(["--cls=time.time"]))
+
+
 def test_type_typehint_help_known_subclasses(parser):
     parser.add_argument("--cls", type=Type[BaseC])
     help_str = get_parser_help(parser)
@@ -483,11 +499,11 @@ def test_type_typehint_constrained_typevar_arg(parser):
 # typevar as the type itself tests
 
 
-class TypeVarOptions(TypedDict, total=False):
+class TypeVarTypedDict(TypedDict, total=False):
     temperature: float
 
 
-BoundTypedDictVar = TypeVar("BoundTypedDictVar", bound=TypeVarOptions)
+BoundTypedDictVar = TypeVar("BoundTypedDictVar", bound=TypeVarTypedDict)
 
 GenericVar = TypeVar("GenericVar")
 
@@ -499,18 +515,35 @@ skip_if_no_generic_typed_dict = pytest.mark.skipif(
 
 if generic_typed_dict_support:
 
-    class GenericOptions(TypedDict, Generic[GenericVar], total=False):
+    class GenericTypedDict(TypedDict, Generic[GenericVar], total=False):
+        """Generic options.
+
+        Args:
+            temperature: How random.
+            extra: Anything else.
+        """
+
         temperature: float
         stop: List[str]
         extra: GenericVar
         extras: List[GenericVar]
+
+    class InheritsSubscriptedTypedDict(GenericTypedDict[int], total=False):
+        """Inherits subscripted options."""
+
+        name: str
+
+    class InheritsGenericTypedDict(GenericTypedDict[GenericVar], total=False):
+        """Inherits generic options."""
+
+        other: GenericVar
 
 
 def test_typevar_bound_argument(parser):
     parser.add_argument("--options", type=Optional[BoundTypedDictVar])
     assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
     pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"unknown": 1}']))
-    assert f"(type: {type_to_str(Optional[TypeVarOptions])}, default: null)" in get_parser_help(parser)
+    assert f"(type: {type_to_str(Optional[TypeVarTypedDict])}, default: null)" in get_parser_help(parser)
 
 
 def function_typevar_bound(options: Optional[BoundTypedDictVar] = None):
@@ -545,22 +578,22 @@ def test_typevar_unbound_signature_parameter(parser):
 def test_typevar_default_argument(parser):
     from typing_extensions import TypeVar as TypeVarExt
 
-    default_var = TypeVarExt("default_var", bound=Mapping[str, Any], default=TypeVarOptions)
+    default_var = TypeVarExt("default_var", bound=Mapping[str, Any], default=TypeVarTypedDict)
     parser.add_argument("--options", type=Optional[default_var])
     assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
     pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"unknown": 1}']))
-    assert f"(type: {type_to_str(Optional[TypeVarOptions])}, default: null)" in get_parser_help(parser)
+    assert f"(type: {type_to_str(Optional[TypeVarTypedDict])}, default: null)" in get_parser_help(parser)
 
 
 @pytest.mark.skipif(not typing_extensions_support, reason="typing_extensions package is required")
 def test_typevar_default_forward_ref(parser):
     from typing_extensions import TypeVar as TypeVarExt
 
-    default_var = TypeVarExt("default_var", bound=Mapping[str, Any], default="TypeVarOptions")
+    default_var = TypeVarExt("default_var", bound=Mapping[str, Any], default="TypeVarTypedDict")
     parser.add_argument("--options", type=Optional[default_var])
     assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
     pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"unknown": 1}']))
-    assert f"(type: {type_to_str(Optional[TypeVarOptions])}, default: null)" in get_parser_help(parser)
+    assert f"(type: {type_to_str(Optional[TypeVarTypedDict])}, default: null)" in get_parser_help(parser)
 
 
 @pytest.mark.skipif(not typing_extensions_support, reason="typing_extensions package is required")
@@ -568,12 +601,12 @@ def test_typevar_default_forward_ref(parser):
 def test_typevar_default_forward_ref_subscripted_generic_typeddict(parser):
     from typing_extensions import TypeVar as TypeVarExt
 
-    default_var = TypeVarExt("default_var", bound=Mapping[str, Any], default="GenericOptions[int]")
+    default_var = TypeVarExt("default_var", bound=Mapping[str, Any], default="GenericTypedDict[int]")
     parser.add_argument("--options", type=Optional[default_var])
     assert parser.parse_args(['--options={"extra": 1}']).options == {"extra": 1}
     pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"extra": "x"}']))
     help_str = get_parser_help(parser)
-    assert f"(type: {type_to_str(Optional[GenericOptions[int]])}, default: null)" in help_str
+    assert f"(type: {type_to_str(Optional[GenericTypedDict[int]])}, default: null)" in help_str
     assert "Unvalidated" not in help_str
 
 
@@ -591,10 +624,35 @@ def function_typevar_unresolvable_bound(options: Optional[UnresolvableBoundVar] 
 
 
 def test_typevar_bound_forward_ref(parser):
-    bound_var = TypeVar("bound_var", bound="TypeVarOptions")
+    bound_var = TypeVar("bound_var", bound="TypeVarTypedDict")
     parser.add_argument("--options", type=Optional[bound_var])
     assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
     pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"unknown": 1}']))
+
+
+def test_typevar_unresolvable_forward_ref_argument(parser):
+    parser.add_argument("--options", type=Optional[UnresolvableBoundVar])
+    # the bound fails to resolve, so the value is accepted without validation
+    assert parser.parse_args(['--options={"anything": 1}']).options == {"anything": 1}
+    assert parser.parse_args(["--options=abc"]).options == "abc"
+    assert "Unvalidated<MisspelledOptions>" in get_parser_help(parser)
+
+
+def test_typevar_unresolvable_forward_ref_constraint(parser):
+    constrained_var = TypeVar("constrained_var", "MisspelledOptions", int)  # noqa: F821
+    parser.add_argument("--options", type=Optional[constrained_var])
+    assert parser.parse_args(["--options=1"]).options == 1
+    # the constraint that fails to resolve accepts any value
+    assert parser.parse_args(['--options={"anything": 1}']).options == {"anything": 1}
+    assert "Unvalidated<MisspelledOptions>" in get_parser_help(parser)
+
+
+def test_type_typevar_unresolvable_forward_ref_bound(parser):
+    parser.add_argument("--cls", type=type[UnresolvableBoundVar])
+    # the bound fails to resolve, so any class is accepted
+    assert parser.parse_args(["--cls=calendar.Calendar"]).cls is calendar.Calendar
+    pytest.raises(ArgumentError, lambda: parser.parse_args(["--cls=not_a_class"]))
+    assert "(type: type[Unvalidated<MisspelledOptions>], default: null)" in get_parser_help(parser)
 
 
 # enum tests
@@ -1115,7 +1173,7 @@ def test_required_support():
 
 @skip_if_no_generic_typed_dict
 def test_subscripted_generic_typeddict(parser):
-    parser.add_argument("--options", type=Optional[GenericOptions[int]])
+    parser.add_argument("--options", type=Optional[GenericTypedDict[int]])
     assert parser.parse_args(['--options={"temperature": 0.5, "stop": ["x"], "extra": 1, "extras": [2]}']).options == {
         "temperature": 0.5,
         "stop": ["x"],
@@ -1131,16 +1189,115 @@ def test_subscripted_generic_typeddict(parser):
     with pytest.raises(ArgumentError) as ctx:
         parser.parse_args(['--options={"extras": ["x"]}'])
     ctx.match("Expected a <class 'int'>")
-    assert f"(type: {type_to_str(Optional[GenericOptions[int]])}, default: null)" in get_parser_help(parser)
+    assert f"(type: {type_to_str(Optional[GenericTypedDict[int]])}, default: null)" in get_parser_help(parser)
 
 
-def test_subscripted_non_generic_typeddict(parser):
-    parser.add_argument("--options", type=Optional[TypeVarOptions[None]])
+@skip_if_no_generic_typed_dict
+def test_subscripted_generic_typeddict_help(parser):
+    parser.add_argument("--options", type=Optional[GenericTypedDict[int]])
+    help_str = get_parse_args_stdout(parser, ["--options.help"])
+    assert f"Help for --options.help={__name__}.GenericTypedDict" in help_str
+    # the keys show what the type arguments substitute, the same as the value is validated
+    assert "--options.extra EXTRA" in help_str
+    assert "(type: int)" in help_str
+    assert "--options.extras [ITEM,...]" in help_str
+    assert f"(type: {type_to_str(List[int])})" in help_str
+
+
+@skip_if_docstring_parser_unavailable
+@skip_if_no_generic_typed_dict
+def test_subscripted_generic_typeddict_help_docstrings(parser):
+    parser.add_argument("--options", type=Optional[GenericTypedDict[int]])
+    help_str = get_parse_args_stdout(parser, ["--options.help"])
+    assert "Generic options:" in help_str
+    assert "Anything else. (type: int)" in help_str
+
+
+@skip_if_no_generic_typed_dict
+def test_unsubscripted_generic_typeddict(parser):
+    parser.add_argument("--options", type=Optional[GenericTypedDict])
+    # an unbound TypeVar stands for nothing, so the key accepts any value
+    assert parser.parse_args(['--options={"extra": [1, "x"]}']).options == {"extra": [1, "x"]}
     assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
     with pytest.raises(ArgumentError) as ctx:
         parser.parse_args(['--options={"unknown": 1}'])
     ctx.match("Unexpected keys")
-    assert f"(type: {type_to_str(Optional[TypeVarOptions[None]])}, default: null)" in get_parser_help(parser)
+    help_str = get_parse_args_stdout(parser, ["--options.help"])
+    assert "--options.extra EXTRA" in help_str
+    assert "(type: Unvalidated<GenericVar>)" in help_str
+
+
+@skip_if_no_generic_typed_dict
+def test_subscripted_generic_typeddict_with_typevar(parser):
+    parser.add_argument("--options", type=Optional[GenericTypedDict[GenericVar]])
+    # subscripted with a TypeVar that stands for nothing, so the key accepts any value
+    assert parser.parse_args(['--options={"extra": [1, "x"]}']).options == {"extra": [1, "x"]}
+    assert parser.parse_args(['--options={"stop": ["x"]}']).options == {"stop": ["x"]}
+
+
+@skip_if_no_generic_typed_dict
+def test_typeddict_inherits_subscripted_generic(parser):
+    parser.add_argument("--options", type=Optional[InheritsSubscriptedTypedDict])
+    # the key inherited from GenericTypedDict[int] is validated as an int
+    assert parser.parse_args(['--options={"extra": 1, "name": "x"}']).options == {"extra": 1, "name": "x"}
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--options={"extra": "x"}'])
+    ctx.match("Expected a <class 'int'>")
+
+
+@skip_if_no_generic_typed_dict
+def test_typeddict_inherits_generic_subscripted(parser):
+    parser.add_argument("--options", type=Optional[InheritsGenericTypedDict[str]])
+    # the TypeVar of the base and of the subclass both stand for str
+    assert parser.parse_args(['--options={"extra": "x", "other": "y"}']).options == {"extra": "x", "other": "y"}
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--options={"extra": 1}'])
+    ctx.match("Expected a <class 'str'>")
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--options={"other": 1}'])
+    ctx.match("Expected a <class 'str'>")
+
+
+IntBoundVar = TypeVar("IntBoundVar", bound=int)
+
+if generic_typed_dict_support:
+
+    class BoundVarOptions(TypedDict, Generic[IntBoundVar], total=False):
+        value: IntBoundVar
+
+
+@skip_if_no_generic_typed_dict
+def test_typeddict_key_bound_typevar(parser):
+    parser.add_argument("--options", type=Optional[BoundVarOptions])
+    # not subscripted, so the TypeVar stands for its bound
+    assert parser.parse_args(['--options={"value": 1}']).options == {"value": 1}
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--options={"value": "x"}'])
+    ctx.match("Expected a <class 'int'>")
+
+
+class UnsupportedKeyOptions(TypedDict, total=False):
+    supported: int
+    unsupported: Iterator[int]
+
+
+def test_typeddict_key_unsupported_type(parser):
+    parser.add_argument("--options", type=Optional[UnsupportedKeyOptions])
+    assert parser.parse_args(['--options={"supported": 1}']).options == {"supported": 1}
+    # a key that can't be validated accepts any value, the same as the help shows it
+    assert parser.parse_args(['--options={"unsupported": [1]}']).options == {"unsupported": [1]}
+    help_str = get_parse_args_stdout(parser, ["--options.help"])
+    assert "--options.unsupported UNSUPPORTED" in help_str
+    assert "(type: Unvalidated<Iterator[int]>)" in help_str
+
+
+def test_subscripted_non_generic_typeddict(parser):
+    parser.add_argument("--options", type=Optional[TypeVarTypedDict[None]])
+    assert parser.parse_args(['--options={"temperature": 0.5}']).options == {"temperature": 0.5}
+    with pytest.raises(ArgumentError) as ctx:
+        parser.parse_args(['--options={"unknown": 1}'])
+    ctx.match("Unexpected keys")
+    assert f"(type: {type_to_str(Optional[TypeVarTypedDict[None]])}, default: null)" in get_parser_help(parser)
 
 
 @pytest.mark.skipif(not typing_extensions_support, reason="typing_extensions package is required")
@@ -1148,12 +1305,12 @@ def test_subscripted_non_generic_typeddict(parser):
 def test_typevar_default_subscripted_generic_typeddict(parser):
     from typing_extensions import TypeVar as TypeVarExt
 
-    options_var = TypeVarExt("options_var", bound=Mapping[str, Any], default=GenericOptions[int])
+    options_var = TypeVarExt("options_var", bound=Mapping[str, Any], default=GenericTypedDict[int])
     parser.add_argument("--options", type=Optional[options_var])
     assert parser.parse_args(['--options={"extra": 1}']).options == {"extra": 1}
     pytest.raises(ArgumentError, lambda: parser.parse_args(['--options={"unknown": 1}']))
     help_str = get_parser_help(parser)
-    assert f"(type: {type_to_str(Optional[GenericOptions[int]])}, default: null)" in help_str
+    assert f"(type: {type_to_str(Optional[GenericTypedDict[int]])}, default: null)" in help_str
     assert "Unvalidated" not in help_str
 
 
@@ -2417,6 +2574,25 @@ def test_callable_protocol_instance_factory(parser, subtests):
         assert f"Help for --optimizer.help={__name__}.DifferentParamsOrder" in help_str
         assert "--optimizer.lr" in help_str
         assert "--optimizer.params" not in help_str
+
+
+OptimizerVar = TypeVar("OptimizerVar", covariant=True)
+
+
+class GenericOptimizerFactory(Protocol[OptimizerVar]):
+    def __call__(self, params: List[float]) -> OptimizerVar: ...
+
+
+def test_subscripted_generic_callable_protocol_instance_factory(parser):
+    parser.add_argument("--optimizer", type=GenericOptimizerFactory[Optimizer])
+    # the return type of __call__ is what the protocol is subscripted with, so
+    # the class is resolved by name from the subclasses of Optimizer
+    cfg = parser.parse_args(["--optimizer=Adam", "--optimizer.lr=0.01"])
+    assert cfg.optimizer.class_path == f"{__name__}.Adam"
+    init = parser.instantiate(cfg)
+    optimizer = init.optimizer(params=[1, 2])
+    assert isinstance(optimizer, Adam)
+    assert optimizer.lr == 0.01
 
 
 class OptimizerFactoryPositionalAndKeyword(Protocol):


### PR DESCRIPTION
## What does this PR do?

Extends the type hint support for generics and unifies the handling of `object`
with `Any`.

**Added**

- Support for a subscripted generic `TypedDict`, e.g. `SomeDict[int]`, and for a `TypedDict` that inherits from one, e.g. `class SubDict(SomeDict[int])`, both previously unsupported. Subscripting doesn't change which keys are accepted, only the types of the keys annotated with a `TypeVar`, composing the substitutions along the inheritance chain. Works for parsing, the `--*.help` option and shtab completions.
- A `TypeVar` `default`, constraint or bound given as a forward reference is now resolved with the names of the module in which the `TypeVar` is defined. An unresolvable reference becomes an `Unvalidated<...>` instead of failing.
- Keys of a `TypedDict` whose type can't be validated now accept any value, the same as signature parameters already did.

**Fixed**

- A subscripted generic `Protocol`, e.g. `Proto[int]`, never being implementable. The type arguments are now substituted into the protocol's method signatures and return types, so `Proto[int]` and `Proto[str]` accept different implementations, and a `TypeVar` that remains matches any type, as static type checkers do. This also applies to instance factory protocols, i.e. the return type of a subscripted protocol's `__call__`.
- Internal `RuntimeError` when giving a value for a `TypedDict` key annotated with a `TypeVar`.
- `type[Any]` rejecting every value, instead of accepting any class as bare `type` does.
- The docstring of a subscripted generic class not being used, so the group description and the parameter descriptions were missing in the help.
- Nested namespaces in `init_args`, e.g. a subclass spec kept as is for an `Any` typed parameter, being expanded into keyword arguments on `instantiate`.

**Changed**

- `object` as a type is now handled exactly like `Any`, since in standard typing every value is an instance of it. This means it no longer only accepts the import path of a class, it accepts any value, it participates in the `validate_subclass_spec_in_any` and `instantiate_subclass_spec_in_any` settings, it is sorted last in unions together with `Any` and `Unvalidated<...>`, and dumping it warns about values that lose their type.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/mauvilsa/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] If you used a **coding agent**, did you fully understand and validate all generated code and ensure it follows the contributing guidelines?
- [x] Did you update **the documentation**? (readme and public docstrings)
- [x] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [x] If this is a **bug fix**, did you verify that the **tests fail without the code fix**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)