### PR TITLE
Replace toml with tomli w

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,6 @@ repos:
       [
         types-PyYAML,
         types-requests,
-        types-toml,
       ]
     verbose: true
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,8 +58,8 @@ Changed
   <https://github.com/mauvilsa/jsonargparse/pull/972>`__).
 - The ``toml`` extra now installs the maintained ``tomli-w`` for writing and
   ``tomli`` for reading in python 3.10, instead of the unmaintained ``toml``
-  package. Dumped toml arrays are now multi-line (`#???
-  <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
+  package. Dumped toml arrays are now multi-line (`#973
+  <https://github.com/mauvilsa/jsonargparse/pull/973>`__).
 
 Removed
 ^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,6 +56,10 @@ Changed
 - The ``yaml`` dump format now writes multi-line strings as literal blocks, i.e.
   ``|``, instead of escaping the line breaks (`#972
   <https://github.com/mauvilsa/jsonargparse/pull/972>`__).
+- The ``toml`` extra now installs the maintained ``tomli-w`` for writing and
+  ``tomli`` for reading in python 3.10, instead of the unmaintained ``toml``
+  package. Dumped toml arrays are now multi-line (`#???
+  <https://github.com/mauvilsa/jsonargparse/pull/???>`__).
 
 Removed
 ^^^^^^^

--- a/jsonargparse/_optionals.py
+++ b/jsonargparse/_optionals.py
@@ -11,8 +11,8 @@ from importlib.util import find_spec
 from typing import Any, Union
 
 pyyaml_available = bool(find_spec("yaml"))
-toml_load_available = bool(find_spec("toml") or find_spec("tomllib"))
-toml_dump_available = bool(find_spec("toml"))
+toml_load_available = bool(find_spec("tomllib") or find_spec("tomli"))
+toml_dump_available = bool(find_spec("tomli_w"))
 typing_extensions_support = find_spec("typing_extensions") is not None
 typeshed_client_support = find_spec("typeshed_client") is not None
 jsonschema_support = find_spec("jsonschema") is not None
@@ -113,16 +113,16 @@ def import_toml_loads(importer):
 
         return tomllib.loads, tomllib.TOMLDecodeError
     else:
-        with missing_package_raise("toml", importer):
-            import toml
+        with missing_package_raise("tomli", importer):
+            import tomli
 
-        return toml.loads, toml.TomlDecodeError
+        return tomli.loads, tomli.TOMLDecodeError
 
 
 def import_toml_dumps(importer):
-    with missing_package_raise("toml", importer):
-        import toml
-    return toml.dumps
+    with missing_package_raise("tomli-w", importer):
+        import tomli_w
+    return tomli_w.dumps
 
 
 def import_jsonschema(importer):

--- a/jsonargparse_tests/test_loaders_dumpers.py
+++ b/jsonargparse_tests/test_loaders_dumpers.py
@@ -194,11 +194,14 @@ root = "-"
 
 [group]
 child1 = 1.2
-child2 = [ 3.0, 4.5,]
+child2 = [
+    3.0,
+    4.5,
+]
 """
 
 
-@pytest.mark.skipif(not toml_load_available, reason="tomllib or toml package is required")
+@pytest.mark.skipif(not toml_load_available, reason="tomllib or tomli package is required")
 def test_toml_parse_args_config(parser, tmp_cwd):
     parser.parser_mode = "toml"
     config_path = Path("config.toml")
@@ -212,7 +215,7 @@ def test_toml_parse_args_config(parser, tmp_cwd):
     assert cfg.group.as_dict() == {"child1": 1.2, "child2": [3.0, 4.5]}
 
 
-@pytest.mark.skipif(not toml_dump_available, reason="toml package is required")
+@pytest.mark.skipif(not toml_dump_available, reason="tomli-w package is required")
 def test_toml_print_config(parser):
     parser.parser_mode = "toml"
     parser.add_argument("--config", action="config")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ yaml = [
     "PyYAML>=3.13",
 ]
 toml = [
-    "toml>=0.10.2",
+    "tomli>=2.0.1; python_version < '3.11'",
+    "tomli-w>=1.0.0",
 ]
 jsonnet = [
     "jsonnet>=0.21.0",


### PR DESCRIPTION
## What does this PR do?

Fixes #962

Moves the `toml` extra off the unmaintained [`toml`](https://pypi.org/project/toml/) package.

Reading already preferred the standard library `tomllib` when available, so the only real dependency on `toml` was writing, plus reading in python 3.10 where `tomllib` does not exist. The extra now installs:

- `tomli-w` for writing.
- `tomli` for reading, only for `python_version < '3.11'`.

Changes:

- `pyproject.toml`: the `toml` extra requires `tomli-w>=1.0.0` and `tomli>=2.0.1; python_version < '3.11'`. The extra name is unchanged.
- `_optionals.py`: `toml_load_available` now checks `tomllib` or `tomli`, `toml_dump_available` checks `tomli_w`, and `import_toml_loads` / `import_toml_dumps` import accordingly.
- `.pre-commit-config.yaml`: dropped the `types-toml` mypy dependency, since `tomli` and `tomli-w` ship their own type hints.

Note on behavior: `tomli-w` writes arrays multi-line, where `toml` wrote them inline. So dumping a list now gives:

```toml
child2 = [
    3.0,
    4.5,
]
```

instead of `child2 = [ 3.0, 4.5,]`. The output is still valid TOML and parses back to the same value, but it is a visible difference for anyone comparing dumped configs, so it is mentioned in the changelog.

## Before submitting

- [x] Did you read the [contributing guideline](https://github.com/mauvilsa/jsonargparse/blob/main/CONTRIBUTING.rst)?
- [x] If you used a **coding agent**, did you fully understand and validate all generated code and ensure it follows the contributing guidelines?
- [n/a] Did you update **the documentation**? (readme and public docstrings)
- [n/a] Did you write **unit tests** such that there is 100% coverage on related code? (required for bug fixes and new features)
- [x] Did you verify that new and existing **tests pass locally**?
- [n/a] If this is a **bug fix**, did you verify that the **tests fail without the code fix**?
- [x] Did you make sure that all changes preserve **backward compatibility**?
- [x] Did you update **the CHANGELOG** including a pull request link? (not for typos, docs, test updates, or minor internal changes/refactors)
